### PR TITLE
Change hardcoded paths to Path.Combine for cross-platform support

### DIFF
--- a/xivModdingFramework/Cache/XivCache.cs
+++ b/xivModdingFramework/Cache/XivCache.cs
@@ -350,7 +350,7 @@ namespace xivModdingFramework.Cache
                     using (var db = new SQLiteConnection(RootsCacheConnectionString))
                     {
                         db.Open();
-                        var lines = File.ReadAllLines(Path.Combine("Resources", "SQL", rootCacheCreationScript));
+                        var lines = File.ReadAllLines(Path.Combine(cwd, "Resources", "SQL", rootCacheCreationScript));
                         var sqlCmd = String.Join("\n", lines);
 
                         using (var cmd = new SQLiteCommand(sqlCmd, db))
@@ -1435,6 +1435,7 @@ namespace xivModdingFramework.Cache
 
         public static void ResetRootCache()
         {
+            var cwd = System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetEntryAssembly().Location);
 
             SQLiteConnection.ClearAllPools();
             GC.WaitForPendingFinalizers();
@@ -1443,7 +1444,7 @@ namespace xivModdingFramework.Cache
             using (var db = new SQLiteConnection(RootsCacheConnectionString))
             {
                 db.Open();
-                var lines = File.ReadAllLines(Path.Combine("Resources", "SQL", rootCacheCreationScript));
+                var lines = File.ReadAllLines(Path.Combine(cwd, "Resources", "SQL", rootCacheCreationScript));
                 var sqlCmd = String.Join("\n", lines);
 
                 using (var cmd = new SQLiteCommand(sqlCmd, db))

--- a/xivModdingFramework/Cache/XivCache.cs
+++ b/xivModdingFramework/Cache/XivCache.cs
@@ -319,7 +319,7 @@ namespace xivModdingFramework.Cache
             using (var db = new SQLiteConnection(CacheConnectionString))
             {
                 db.Open();
-                var lines = File.ReadAllLines(cwd + "\\Resources\\SQL\\" + creationScript);
+                var lines = File.ReadAllLines(Path.Combine(cwd, "Resources", "SQL", creationScript));
                 var sqlCmd = String.Join("\n", lines);
 
                 using (var cmd = new SQLiteCommand(sqlCmd, db))
@@ -328,7 +328,7 @@ namespace xivModdingFramework.Cache
                 }
             }
 
-            var backupFile = cwd + "\\Resources\\DB\\" + rootCacheFileName;
+            var backupFile = Path.Combine(cwd,"Resources", "DB", rootCacheFileName);
 
             if (!File.Exists(_rootCachePath.FullName))
             {
@@ -350,7 +350,7 @@ namespace xivModdingFramework.Cache
                     using (var db = new SQLiteConnection(RootsCacheConnectionString))
                     {
                         db.Open();
-                        var lines = File.ReadAllLines("Resources\\SQL\\" + rootCacheCreationScript);
+                        var lines = File.ReadAllLines(Path.Combine("Resources", "SQL", rootCacheCreationScript));
                         var sqlCmd = String.Join("\n", lines);
 
                         using (var cmd = new SQLiteCommand(sqlCmd, db))
@@ -1443,7 +1443,7 @@ namespace xivModdingFramework.Cache
             using (var db = new SQLiteConnection(RootsCacheConnectionString))
             {
                 db.Open();
-                var lines = File.ReadAllLines("Resources\\SQL\\" + rootCacheCreationScript);
+                var lines = File.ReadAllLines(Path.Combine("Resources", "SQL", rootCacheCreationScript));
                 var sqlCmd = String.Join("\n", lines);
 
                 using (var cmd = new SQLiteCommand(sqlCmd, db))

--- a/xivModdingFramework/General/GameInfo.cs
+++ b/xivModdingFramework/General/GameInfo.cs
@@ -53,7 +53,7 @@ namespace xivModdingFramework
             GameLanguage  = xivLanguage;
             GameVersion   = GetGameVersion();
 
-            if (!gameDirectory.FullName.Contains("game\\sqpack\\ffxiv"))
+            if (!gameDirectory.FullName.Contains(Path.Combine("game", "sqpack", "ffxiv")))
             {
                 throw new DirectoryNotFoundException("The given directory is incorrect.\n\nThe directory sould point to the \\game\\sqpack\\ffxiv folder");
             }
@@ -67,7 +67,7 @@ namespace xivModdingFramework
         private Version GetGameVersion()
         {
             var versionBasePath = GameDirectory.FullName.Substring(0, GameDirectory.FullName.IndexOf("sqpack", StringComparison.Ordinal));
-            var versionFile = versionBasePath + "\\" + GameVersionFile;
+            var versionFile = Path.Combine(versionBasePath, GameVersionFile);
 
             var versionData = File.ReadAllLines(versionFile);
             return new Version(versionData[0].Substring(0, versionData[0].LastIndexOf(".", StringComparison.Ordinal)));


### PR DESCRIPTION
Hi!
With ffmt we are trying to keep FFXIV modding available to Mac and Linux users through the use of the xivModdingFramework. Sadly hardcoded paths usually stops the framework from being utilized without errors.

This PR makes the most recent release compatible with Linux and Mac and should not cause any issues.