### PR TITLE
Add support for Lumina saving to all write and copy operations

### DIFF
--- a/xivModdingFramework/Cache/XivCache.cs
+++ b/xivModdingFramework/Cache/XivCache.cs
@@ -18,6 +18,8 @@ using xivModdingFramework.Mods;
 using xivModdingFramework.Resources;
 using xivModdingFramework.SqPack.FileTypes;
 
+using Index = xivModdingFramework.SqPack.FileTypes.Index;
+
 namespace xivModdingFramework.Cache
 {
 

--- a/xivModdingFramework/Cache/XivDependencyGraph.cs
+++ b/xivModdingFramework/Cache/XivDependencyGraph.cs
@@ -26,6 +26,8 @@ using xivModdingFramework.Textures.FileTypes;
 using xivModdingFramework.Variants.FileTypes;
 using static xivModdingFramework.Cache.XivCache;
 
+using Index = xivModdingFramework.SqPack.FileTypes.Index;
+
 namespace xivModdingFramework.Cache
 {
 

--- a/xivModdingFramework/Exd/FileTypes/Ex.cs
+++ b/xivModdingFramework/Exd/FileTypes/Ex.cs
@@ -23,6 +23,8 @@ using xivModdingFramework.General.Enums;
 using xivModdingFramework.Helpers;
 using xivModdingFramework.SqPack.FileTypes;
 
+using Index = xivModdingFramework.SqPack.FileTypes.Index;
+
 namespace xivModdingFramework.Exd.FileTypes
 {
     /// <summary>

--- a/xivModdingFramework/General/CMP.cs
+++ b/xivModdingFramework/General/CMP.cs
@@ -35,14 +35,26 @@ namespace xivModdingFramework.General
         /// <param name="index"></param>
         /// <param name="modlist"></param>
         /// <returns></returns>
-        internal static async Task ApplyRgspFile(string filePath, IndexFile index = null, ModList modlist = null)
+        internal static async Task ApplyRgspFile(string filePath, IndexFile index = null, ModList modlist = null, bool doLumina = false, DirectoryInfo luminaOutDir = null)
         {
             var _dat = new Dat(XivCache.GameInfo.GameDirectory);
             var rgspData = await _dat.GetType2Data(filePath, false, index, modlist);
 
-            var rgsp = new RacialGenderScalingParameter(rgspData);
+            await ApplyRgspFile(rgspData, doLumina: doLumina, luminaOutDir: luminaOutDir);
+        }
 
-            await SetScalingParameter(rgsp, index, modlist);
+        /// <summary>
+        /// Applies a custom .rgsp file to the main Human.CMP file.
+        /// </summary>
+        /// <param name="data"></param>
+        /// <param name="index"></param>
+        /// <param name="modlist"></param>
+        /// <returns></returns>
+        internal static async Task ApplyRgspFile(byte[] data, IndexFile index = null, ModList modlist = null, bool doLumina = false, DirectoryInfo luminaOutDir = null)
+        {
+            var rgsp = new RacialGenderScalingParameter(data);
+
+            await SetScalingParameter(rgsp, index, modlist, doLumina, luminaOutDir);
         }
 
         /// <summary>
@@ -155,11 +167,11 @@ namespace xivModdingFramework.General
         /// <param name="index"></param>
         /// <param name="modlist"></param>
         /// <returns></returns>
-        private static async Task SetScalingParameter(RacialGenderScalingParameter data, IndexFile index = null, ModList modlist = null)
+        private static async Task SetScalingParameter(RacialGenderScalingParameter data, IndexFile index = null, ModList modlist = null, bool doLumina = false, DirectoryInfo luminaOutDir = null)
         {
             var cmp = await GetCharaMakeParameterSet(false, index, modlist);
             cmp.SetScalingParameter(data);
-            await SaveCharaMakeParameterSet(cmp, index, modlist);
+            await SaveCharaMakeParameterSet(cmp, index, modlist, doLumina, luminaOutDir);
         }
 
         private static async Task<CharaMakeParameterSet> GetCharaMakeParameterSet(bool forceOriginal = false, IndexFile index = null, ModList modlist = null)
@@ -173,14 +185,14 @@ namespace xivModdingFramework.General
             return cmp;
         }
 
-        private static async Task SaveCharaMakeParameterSet(CharaMakeParameterSet cmp, IndexFile index = null, ModList modlist = null)
+        private static async Task SaveCharaMakeParameterSet(CharaMakeParameterSet cmp, IndexFile index = null, ModList modlist = null, bool doLumina = false, DirectoryInfo luminaOutDir = null)
         {
             var _dat = new Dat(XivCache.GameInfo.GameDirectory);
             var dummyItem = new XivGenericItemModel();
             dummyItem.Name = "human.cmp";
             dummyItem.SecondaryCategory = Constants.InternalModSourceName;
 
-            await _dat.ImportType2Data(cmp.GetBytes(), HumanCmpPath, Constants.InternalModSourceName, dummyItem, index, modlist);
+            await _dat.ImportType2Data(cmp.GetBytes(), HumanCmpPath, Constants.InternalModSourceName, dummyItem, index, modlist, doLumina, luminaOutDir);
         }
 
     }

--- a/xivModdingFramework/HUD/FileTypes/Uld.cs
+++ b/xivModdingFramework/HUD/FileTypes/Uld.cs
@@ -25,6 +25,8 @@ using xivModdingFramework.General.Enums;
 using xivModdingFramework.Helpers;
 using xivModdingFramework.SqPack.FileTypes;
 
+using Index = xivModdingFramework.SqPack.FileTypes.Index;
+
 namespace xivModdingFramework.HUD.FileTypes
 {
     /// <summary>

--- a/xivModdingFramework/Helpers/ProblemChecker.cs
+++ b/xivModdingFramework/Helpers/ProblemChecker.cs
@@ -25,6 +25,8 @@ using xivModdingFramework.Mods;
 using xivModdingFramework.Resources;
 using xivModdingFramework.Cache;
 
+using Index = xivModdingFramework.SqPack.FileTypes.Index;
+
 namespace xivModdingFramework.Helpers
 {
     public class ProblemChecker

--- a/xivModdingFramework/Items/Categories/Gear.cs
+++ b/xivModdingFramework/Items/Categories/Gear.cs
@@ -36,6 +36,8 @@ using xivModdingFramework.Textures.DataContainers;
 using xivModdingFramework.Textures.Enums;
 using xivModdingFramework.Variants.FileTypes;
 
+using Index = xivModdingFramework.SqPack.FileTypes.Index;
+
 namespace xivModdingFramework.Items.Categories
 {
     /// <summary>

--- a/xivModdingFramework/Items/Categories/Housing.cs
+++ b/xivModdingFramework/Items/Categories/Housing.cs
@@ -33,6 +33,8 @@ using xivModdingFramework.Items.Interfaces;
 using xivModdingFramework.Resources;
 using xivModdingFramework.SqPack.FileTypes;
 
+using Index = xivModdingFramework.SqPack.FileTypes.Index;
+
 namespace xivModdingFramework.Items.Categories
 {
     public class Housing

--- a/xivModdingFramework/Materials/FileTypes/Mtrl.cs
+++ b/xivModdingFramework/Materials/FileTypes/Mtrl.cs
@@ -38,6 +38,8 @@ using xivModdingFramework.Textures.Enums;
 using xivModdingFramework.Textures.FileTypes;
 using xivModdingFramework.Variants.FileTypes;
 
+using Index = xivModdingFramework.SqPack.FileTypes.Index;
+
 namespace xivModdingFramework.Materials.FileTypes
 {
     /// <summary>
@@ -687,7 +689,7 @@ namespace xivModdingFramework.Materials.FileTypes
         /// <param name="item">The item whos mtrl is being imported</param>
         /// <param name="source">The source/application that is writing to the dat.</param>
         /// <returns>The new offset</returns>
-        public async Task<long> ImportMtrl(XivMtrl xivMtrl, IItem item, string source, IndexFile cachedIndexFile = null, ModList cachedModList = null)
+        public async Task<long> ImportMtrl(XivMtrl xivMtrl, IItem item, string source, IndexFile cachedIndexFile = null, ModList cachedModList = null, bool doLumina = false, DirectoryInfo luminaOutDir = null)
         {
             try
             {
@@ -695,7 +697,7 @@ namespace xivModdingFramework.Materials.FileTypes
                 var dat = new Dat(_gameDirectory);
 
                 // Create the actual raw MTRL first. - Files should always be created top down.
-                long offset = await dat.ImportType2Data(mtrlBytes.ToArray(), xivMtrl.MTRLPath, source, item, cachedIndexFile, cachedModList);
+                long offset = await dat.ImportType2Data(mtrlBytes.ToArray(), xivMtrl.MTRLPath, source, item, cachedIndexFile, cachedModList, doLumina, luminaOutDir);
 
                 // The MTRL file is now ready to go, but we need to validate the texture paths and create them if needed.
                 var mapInfoList = xivMtrl.GetAllMapInfos(false);
@@ -714,7 +716,7 @@ namespace xivModdingFramework.Materials.FileTypes
                         exists = await _index.FileExists(mapInfo.Path, IOUtil.GetDataFileFromPath(path));
                     }
 
-                    if(exists)
+                    if(exists && !doLumina)
                     {
                         continue;
                     }
@@ -730,7 +732,7 @@ namespace xivModdingFramework.Materials.FileTypes
 
                     var di = Tex.GetDefaultTexturePath(mapInfo.Usage);
 
-                    var newOffset = await _tex.ImportTex(xivTex.TextureTypeAndPath.Path, di.FullName, item, source, cachedIndexFile, cachedModList);
+                    var newOffset = await _tex.ImportTex(xivTex.TextureTypeAndPath.Path, di.FullName, item, source, cachedIndexFile, cachedModList, doLumina, luminaOutDir);
 
                 }
 

--- a/xivModdingFramework/Models/FileTypes/Eqp.cs
+++ b/xivModdingFramework/Models/FileTypes/Eqp.cs
@@ -17,6 +17,8 @@ using xivModdingFramework.Resources;
 using xivModdingFramework.SqPack.DataContainers;
 using xivModdingFramework.SqPack.FileTypes;
 
+using Index = xivModdingFramework.SqPack.FileTypes.Index;
+
 namespace xivModdingFramework.Models.FileTypes
 {
     public class Eqp
@@ -167,7 +169,7 @@ namespace xivModdingFramework.Models.FileTypes
 
         }
 
-        public async Task SaveGimmickParameter(int equipmentId, GimmickParameter param, IItem referenceItem = null, IndexFile cachedIndexFile = null, ModList cachedModList = null)
+        public async Task SaveGimmickParameter(int equipmentId, GimmickParameter param, IItem referenceItem = null, IndexFile cachedIndexFile = null, ModList cachedModList = null, bool doLumina = false, DirectoryInfo luminaOutDir = null)
         {
             if (equipmentId == 0)
             {
@@ -193,7 +195,7 @@ namespace xivModdingFramework.Models.FileTypes
 
             IOUtil.ReplaceBytesAt(data, param.GetBytes(), offset);
 
-            await SaveGimmickParameterFile(data, referenceItem, cachedIndexFile, cachedModList);
+            await SaveGimmickParameterFile(data, referenceItem, cachedIndexFile, cachedModList, doLumina, luminaOutDir);
         }
 
         public async Task<GimmickParameter> GetGimmickParameter(IItem item, bool forceDefault = false)
@@ -249,9 +251,9 @@ namespace xivModdingFramework.Models.FileTypes
             return param;
         }
 
-        private async Task SaveGimmickParameterFile(byte[] bytes, IItem referenceItem = null, IndexFile cachedIndexFile = null, ModList cachedModList = null)
+        private async Task SaveGimmickParameterFile(byte[] bytes, IItem referenceItem = null, IndexFile cachedIndexFile = null, ModList cachedModList = null, bool doLumina = false, DirectoryInfo luminaOutDir = null)
         {
-            await _dat.ImportType2Data(bytes, GimmickParameterFile, Constants.InternalModSourceName, referenceItem, cachedIndexFile, cachedModList);
+            await _dat.ImportType2Data(bytes, GimmickParameterFile, Constants.InternalModSourceName, referenceItem, cachedIndexFile, cachedModList, doLumina, luminaOutDir);
         }
         private async Task<byte[]> LoadGimmickParameterFile(bool forceDefault = false)
         {
@@ -332,7 +334,7 @@ namespace xivModdingFramework.Models.FileTypes
         /// <param name="equipmentId"></param>
         /// <param name="data"></param>
         /// <returns></returns>
-        public async Task SaveEqpEntry(int equipmentId, EquipmentParameter data, IItem referenceItem = null, IndexFile cachedIndexFile = null, ModList cachedModList = null)
+        public async Task SaveEqpEntry(int equipmentId, EquipmentParameter data, IItem referenceItem = null, IndexFile cachedIndexFile = null, ModList cachedModList = null, bool doLumina = false, DirectoryInfo luminaOutDir = null)
         {
             if (equipmentId < 0)
             {
@@ -369,7 +371,7 @@ namespace xivModdingFramework.Models.FileTypes
 
             IOUtil.ReplaceBytesAt(file, bytes, offset);
 
-            await _dat.ImportType2Data(file.ToArray(), EquipmentParameterFile, Constants.InternalModSourceName, referenceItem, cachedIndexFile, cachedModList);
+            await _dat.ImportType2Data(file.ToArray(), EquipmentParameterFile, Constants.InternalModSourceName, referenceItem, cachedIndexFile, cachedModList, doLumina, luminaOutDir);
         }
 
 
@@ -676,7 +678,7 @@ namespace xivModdingFramework.Models.FileTypes
         /// <param name="cachedIndexFile"></param>
         /// <param name="cachedModList"></param>
         /// <returns></returns>
-        public async Task SaveEqdpEntries(Dictionary<XivRace, List<(uint PrimaryId, string Slot, EquipmentDeformationParameter Entry)>> entries, IItem referenceItem, IndexFile cachedIndexFile, ModList cachedModList)
+        public async Task SaveEqdpEntries(Dictionary<XivRace, List<(uint PrimaryId, string Slot, EquipmentDeformationParameter Entry)>> entries, IItem referenceItem, IndexFile cachedIndexFile, ModList cachedModList, bool doLumina = false, DirectoryInfo luminaOutDir = null)
         {
             // Group entries into Accessories and Non-Accessories.
             var accessories = new Dictionary<XivRace, List<(uint PrimaryId, string Slot, EquipmentDeformationParameter Entry)>>();
@@ -790,7 +792,7 @@ namespace xivModdingFramework.Models.FileTypes
                     data[offset + byteOffset] = byteToModify;
                 }
 
-                await _dat.ImportType2Data(data, fileName, Constants.InternalModSourceName, referenceItem, cachedIndexFile, cachedModList);
+                await _dat.ImportType2Data(data, fileName, Constants.InternalModSourceName, referenceItem, cachedIndexFile, cachedModList, doLumina, luminaOutDir);
             }
 
             // Loop Accessories
@@ -863,14 +865,14 @@ namespace xivModdingFramework.Models.FileTypes
 
                     data[offset + byteOffset] = byteToModify;
                 }
-                await _dat.ImportType2Data(data, fileName, Constants.InternalModSourceName, referenceItem, cachedIndexFile, cachedModList);
+                await _dat.ImportType2Data(data, fileName, Constants.InternalModSourceName, referenceItem, cachedIndexFile, cachedModList, doLumina, luminaOutDir);
 
             }
 
 
         }
 
-        public async Task SaveEqdpEntries(uint primaryId, string slot, Dictionary<XivRace, EquipmentDeformationParameter> parameters, IItem referenceItem = null, IndexFile cachedIndexFile = null, ModList cachedModList = null)
+        public async Task SaveEqdpEntries(uint primaryId, string slot, Dictionary<XivRace, EquipmentDeformationParameter> parameters, IItem referenceItem = null, IndexFile cachedIndexFile = null, ModList cachedModList = null, bool doLumina = false, DirectoryInfo luminaOutDir = null)
         {
             var isAccessory = EquipmentDeformationParameterSet.SlotsAsList(true).Contains(slot);
 
@@ -948,7 +950,7 @@ namespace xivModdingFramework.Models.FileTypes
 
                 data[offset + byteOffset] = byteToModify;
 
-                await _dat.ImportType2Data(data, fileName, Constants.InternalModSourceName, referenceItem, cachedIndexFile, cachedModList);
+                await _dat.ImportType2Data(data, fileName, Constants.InternalModSourceName, referenceItem, cachedIndexFile, cachedModList, doLumina, luminaOutDir);
             }
         }
 

--- a/xivModdingFramework/Models/FileTypes/Est.cs
+++ b/xivModdingFramework/Models/FileTypes/Est.cs
@@ -167,7 +167,7 @@ namespace xivModdingFramework.Models.FileTypes
         /// <param name="type"></param>
         /// <param name="modifiedEntries"></param>
         /// <returns></returns>
-        public static async Task SaveExtraSkeletonEntries(EstType type, List<ExtraSkeletonEntry> modifiedEntries, IItem referenceItem = null, IndexFile cachedIndexFile = null, ModList cachedModList = null)
+        public static async Task SaveExtraSkeletonEntries(EstType type, List<ExtraSkeletonEntry> modifiedEntries, IItem referenceItem = null, IndexFile cachedIndexFile = null, ModList cachedModList = null, bool doLumina = false, DirectoryInfo luminaOutDir = null)
         {
             var entries = await GetEstFile(type, false);
 
@@ -197,7 +197,7 @@ namespace xivModdingFramework.Models.FileTypes
             }
 
             // Save file.
-            await SaveEstFile(type, entries, referenceItem, cachedIndexFile, cachedModList);
+            await SaveEstFile(type, entries, referenceItem, cachedIndexFile, cachedModList, doLumina, luminaOutDir);
         }
 
         public static async Task<Dictionary<XivRace, ExtraSkeletonEntry>> GetExtraSkeletonEntries(IItem item, bool forceDefault = false)
@@ -343,7 +343,7 @@ namespace xivModdingFramework.Models.FileTypes
             return entries;
         }
 
-        private static async Task SaveEstFile(EstType type, Dictionary<XivRace, Dictionary<ushort, ExtraSkeletonEntry>> entries, IItem referenceItem = null, IndexFile cachedIndexFile = null, ModList cachedModList = null)
+        private static async Task SaveEstFile(EstType type, Dictionary<XivRace, Dictionary<ushort, ExtraSkeletonEntry>> entries, IItem referenceItem = null, IndexFile cachedIndexFile = null, ModList cachedModList = null, bool doLumina = false, DirectoryInfo luminaOutDir = null)
         {
             var count = entries.Select(x => x.Value.Count).Aggregate((x, y) => x + y);
 
@@ -369,7 +369,7 @@ namespace xivModdingFramework.Models.FileTypes
 
 
             var _dat = new Dat(_gameDirectory);
-            await _dat.ImportType2Data(data, EstFiles[type], Constants.InternalModSourceName, referenceItem, cachedIndexFile, cachedModList);
+            await _dat.ImportType2Data(data, EstFiles[type], Constants.InternalModSourceName, referenceItem, cachedIndexFile, cachedModList, doLumina, luminaOutDir);
         }
 
     }

--- a/xivModdingFramework/Models/FileTypes/Sklb.cs
+++ b/xivModdingFramework/Models/FileTypes/Sklb.cs
@@ -38,6 +38,8 @@ using xivModdingFramework.Models.DataContainers;
 using xivModdingFramework.Resources;
 using xivModdingFramework.SqPack.FileTypes;
 
+using Index = xivModdingFramework.SqPack.FileTypes.Index;
+
 namespace xivModdingFramework.Models.FileTypes
 {
     /// <summary>

--- a/xivModdingFramework/Mods/FileTypes/ItemMetadata.cs
+++ b/xivModdingFramework/Mods/FileTypes/ItemMetadata.cs
@@ -20,6 +20,8 @@ using xivModdingFramework.SqPack.FileTypes;
 using xivModdingFramework.Variants.DataContainers;
 using xivModdingFramework.Variants.FileTypes;
 
+using Index = xivModdingFramework.SqPack.FileTypes.Index;
+
 namespace xivModdingFramework.Mods.FileTypes
 {
     /// <summary>
@@ -244,7 +246,7 @@ namespace xivModdingFramework.Mods.FileTypes
         /// </summary>
         /// <param name="meta"></param>
         /// <returns></returns>
-        public static async Task SaveMetadata(ItemMetadata meta, string source, IndexFile index = null, ModList modlist = null)
+        public static async Task SaveMetadata(ItemMetadata meta, string source, IndexFile index = null, ModList modlist = null, bool doLumina = false, DirectoryInfo luminaOutDir = null)
         {
             var _dat = new Dat(XivCache.GameInfo.GameDirectory);
             var _modding = new Modding(XivCache.GameInfo.GameDirectory);
@@ -252,7 +254,7 @@ namespace xivModdingFramework.Mods.FileTypes
             var path = meta.Root.Info.GetRootFile();
             var item = meta.Root.GetFirstItem();
 
-            await _dat.ImportType2Data(await Serialize(meta), path, source, item, index, modlist);
+            await _dat.ImportType2Data(await Serialize(meta), path, source, item, index, modlist, doLumina, luminaOutDir);
         }
 
         /// <summary>
@@ -354,7 +356,7 @@ namespace xivModdingFramework.Mods.FileTypes
         /// Applies this Metadata object to the FFXIV file system.
         /// This should only called by Dat.WriteToDat() / RestoreDefaultMetadata()
         /// </summary>
-        internal static async Task ApplyMetadata(ItemMetadata meta, IndexFile index = null, ModList modlist = null)
+        internal static async Task ApplyMetadata(ItemMetadata meta, IndexFile index = null, ModList modlist = null, bool doLumina = false, DirectoryInfo luminaOutDir = null)
         {
             var _eqp = new Eqp(XivCache.GameInfo.GameDirectory);
             var _modding = new Modding(XivCache.GameInfo.GameDirectory);
@@ -380,30 +382,30 @@ namespace xivModdingFramework.Mods.FileTypes
             {
                 var _imc = new Imc(XivCache.GameInfo.GameDirectory);
                 var imcPath = meta.Root.GetRawImcFilePath();
-                await _imc.SaveEntries(imcPath, meta.Root.Info.Slot, meta.ImcEntries, dummyItem, index, modlist);
+                await _imc.SaveEntries(imcPath, meta.Root.Info.Slot, meta.ImcEntries, dummyItem, index, modlist, doLumina, luminaOutDir);
             }
 
             // Applying EQP data via set 0 is not allowed, as it is a special set hard-coded to use Set 1's data.
             if(meta.EqpEntry != null && !(meta.Root.Info.PrimaryType == Items.Enums.XivItemType.equipment && meta.Root.Info.PrimaryId == 0))
             {
-                await _eqp.SaveEqpEntry(meta.Root.Info.PrimaryId, meta.EqpEntry, dummyItem, index, modlist);
+                await _eqp.SaveEqpEntry(meta.Root.Info.PrimaryId, meta.EqpEntry, dummyItem, index, modlist, doLumina, luminaOutDir);
             }
 
             if(meta.EqdpEntries.Count > 0)
             {
-                await _eqp.SaveEqdpEntries((uint)meta.Root.Info.PrimaryId, meta.Root.Info.Slot, meta.EqdpEntries, dummyItem, index, modlist);
+                await _eqp.SaveEqdpEntries((uint)meta.Root.Info.PrimaryId, meta.Root.Info.Slot, meta.EqdpEntries, dummyItem, index, modlist, doLumina, luminaOutDir);
             }
 
             if (meta.EstEntries.Count > 0)
             {
                 var type = Est.GetEstType(meta.Root);
                 var entries = meta.EstEntries.Values.ToList();
-                await Est.SaveExtraSkeletonEntries(type, entries, dummyItem, index, modlist);
+                await Est.SaveExtraSkeletonEntries(type, entries, dummyItem, index, modlist, doLumina, luminaOutDir);
             }
 
             if(meta.GmpEntry != null)
             {
-                await _eqp.SaveGimmickParameter(meta.Root.Info.PrimaryId, meta.GmpEntry, dummyItem, index, modlist);
+                await _eqp.SaveGimmickParameter(meta.Root.Info.PrimaryId, meta.GmpEntry, dummyItem, index, modlist, doLumina, luminaOutDir);
             }
 
             if (doSave)

--- a/xivModdingFramework/Mods/FileTypes/ItemMetadata.cs
+++ b/xivModdingFramework/Mods/FileTypes/ItemMetadata.cs
@@ -408,7 +408,7 @@ namespace xivModdingFramework.Mods.FileTypes
                 await _eqp.SaveGimmickParameter(meta.Root.Info.PrimaryId, meta.GmpEntry, dummyItem, index, modlist, doLumina, luminaOutDir);
             }
 
-            if (doSave)
+            if (doSave && !doLumina)
             {
                 await _index.SaveIndexFile(index);
                 await _modding.SaveModListAsync(modlist);

--- a/xivModdingFramework/Mods/FileTypes/TTMP.cs
+++ b/xivModdingFramework/Mods/FileTypes/TTMP.cs
@@ -34,6 +34,8 @@ using xivModdingFramework.Resources;
 using xivModdingFramework.SqPack.DataContainers;
 using xivModdingFramework.SqPack.FileTypes;
 
+using Index = xivModdingFramework.SqPack.FileTypes.Index;
+
 namespace xivModdingFramework.Mods.FileTypes
 {
     public class TTMP

--- a/xivModdingFramework/Mods/Modding.cs
+++ b/xivModdingFramework/Mods/Modding.cs
@@ -39,6 +39,8 @@ using xivModdingFramework.SqPack.FileTypes;
 using xivModdingFramework.Variants.DataContainers;
 using xivModdingFramework.Variants.FileTypes;
 
+using Index = xivModdingFramework.SqPack.FileTypes.Index;
+
 namespace xivModdingFramework.Mods
 {
     /// <summary>

--- a/xivModdingFramework/Mods/RootCloner.cs
+++ b/xivModdingFramework/Mods/RootCloner.cs
@@ -21,6 +21,8 @@ using xivModdingFramework.Textures.FileTypes;
 using xivModdingFramework.Variants.DataContainers;
 using xivModdingFramework.Variants.FileTypes;
 
+using Index = xivModdingFramework.SqPack.FileTypes.Index;
+
 namespace xivModdingFramework.Mods
 {
     public static class RootCloner

--- a/xivModdingFramework/Textures/FileTypes/ATex.cs
+++ b/xivModdingFramework/Textures/FileTypes/ATex.cs
@@ -30,6 +30,8 @@ using xivModdingFramework.Textures.DataContainers;
 using xivModdingFramework.Variants.FileTypes;
 using xivModdingFramework.VFX.FileTypes;
 
+using Index = xivModdingFramework.SqPack.FileTypes.Index;
+
 namespace xivModdingFramework.Textures.FileTypes
 {
     public class ATex

--- a/xivModdingFramework/Textures/FileTypes/Tex.cs
+++ b/xivModdingFramework/Textures/FileTypes/Tex.cs
@@ -40,7 +40,9 @@ using xivModdingFramework.SqPack.FileTypes;
 using xivModdingFramework.Textures.DataContainers;
 using xivModdingFramework.Textures.Enums;
 using xivModdingFramework.Variants.FileTypes;
+
 using Surface = TeximpNet.Surface;
+using Index = xivModdingFramework.SqPack.FileTypes.Index;
 
 namespace xivModdingFramework.Textures.FileTypes
 {
@@ -856,7 +858,7 @@ namespace xivModdingFramework.Textures.FileTypes
             }
         }
 
-        public async Task<long> ImportTex(string internalPath, string externalPath, IItem item, string source, IndexFile cachedIndexFile = null, ModList cachedModList = null)
+        public async Task<long> ImportTex(string internalPath, string externalPath, IItem item, string source, IndexFile cachedIndexFile = null, ModList cachedModList = null, bool doLumina = false, DirectoryInfo luminaOutDir = null)
         {
             long offset = 0;
             var path = internalPath;
@@ -875,7 +877,7 @@ namespace xivModdingFramework.Textures.FileTypes
 
             var type = Path.GetExtension(path) == ".atex" ? 2 : 4;
 
-            offset = await _dat.WriteModFile(data, path, source, item, cachedIndexFile, cachedModList);
+            offset = await _dat.WriteModFile(data, path, source, item, cachedIndexFile, cachedModList, doLumina, luminaOutDir);
             return offset;
         }
 
@@ -888,7 +890,7 @@ namespace xivModdingFramework.Textures.FileTypes
         /// <param name="item">The item</param>
         /// <param name="source">The source importing the file</param>
         /// <returns>The new offset</returns>
-        public async Task<long> TexColorImporter(XivMtrl xivMtrl, DirectoryInfo ddsFileDirectory, IItem item, string source, XivLanguage lang)
+        public async Task<long> TexColorImporter(XivMtrl xivMtrl, DirectoryInfo ddsFileDirectory, IItem item, string source, XivLanguage lang, bool doLumina = false, DirectoryInfo luminaOutDir = null)
         {
             var colorSetData = new List<Half>();
             byte[] colorSetExtraData = null;
@@ -907,7 +909,7 @@ namespace xivModdingFramework.Textures.FileTypes
             }
 
             var _mtrl = new Mtrl(XivCache.GameInfo.GameDirectory);
-            return await _mtrl.ImportMtrl(xivMtrl, item, source);
+            return await _mtrl.ImportMtrl(xivMtrl, item, source, doLumina: doLumina, luminaOutDir: luminaOutDir);
         }
 
 

--- a/xivModdingFramework/Variants/FileTypes/Imc.cs
+++ b/xivModdingFramework/Variants/FileTypes/Imc.cs
@@ -31,6 +31,8 @@ using xivModdingFramework.SqPack.DataContainers;
 using xivModdingFramework.SqPack.FileTypes;
 using xivModdingFramework.Variants.DataContainers;
 
+using Index = xivModdingFramework.SqPack.FileTypes.Index;
+
 namespace xivModdingFramework.Variants.FileTypes
 {
     public enum ImcType : short {
@@ -234,7 +236,7 @@ namespace xivModdingFramework.Variants.FileTypes
         /// <param name="path"></param>
         /// <param name="entries"></param>
         /// <returns></returns>
-        internal async Task SaveEntries(string path, string slot, List<XivImc> entries, IItem referenceItem = null, IndexFile cachedIndexFile = null, ModList cachedModList = null)
+        internal async Task SaveEntries(string path, string slot, List<XivImc> entries, IItem referenceItem = null, IndexFile cachedIndexFile = null, ModList cachedModList = null, bool doLumina = false, DirectoryInfo luminaOutDir = null)
         {
             var dat = new Dat(_gameDirectory);
             var index = new Index(_gameDirectory);
@@ -291,7 +293,7 @@ namespace xivModdingFramework.Variants.FileTypes
             }
 
             // Save the modified info.
-            await SaveFullImcInfo(info, path, Constants.InternalModSourceName, referenceItem, cachedIndexFile, cachedModList);
+            await SaveFullImcInfo(info, path, Constants.InternalModSourceName, referenceItem, cachedIndexFile, cachedModList, doLumina, luminaOutDir);
         }
 
         public static byte[] SerializeEntry(XivImc entry)
@@ -453,7 +455,7 @@ namespace xivModdingFramework.Variants.FileTypes
         }
 
 
-        public async Task SaveFullImcInfo(FullImcInfo info, string path, string source, IItem referenceItem = null, IndexFile cachedIndexFile = null, ModList cachedModList = null)
+        public async Task SaveFullImcInfo(FullImcInfo info, string path, string source, IItem referenceItem = null, IndexFile cachedIndexFile = null, ModList cachedModList = null, bool doLumina = false, DirectoryInfo luminaOutDir = null)
         {
             if (info == null || info.TypeIdentifier != ImcType.Set && info.TypeIdentifier != ImcType.NonSet)
             {
@@ -487,7 +489,7 @@ namespace xivModdingFramework.Variants.FileTypes
             // That's it.
             source ??= "Unknown";
 
-            await dat.ImportType2Data(data.ToArray(), path, source, referenceItem, cachedIndexFile, cachedModList);
+            await dat.ImportType2Data(data.ToArray(), path, source, referenceItem, cachedIndexFile, cachedModList, doLumina, luminaOutDir);
         }
 
         /// <summary>

--- a/xivModdingFramework/xivModdingFramework.csproj
+++ b/xivModdingFramework/xivModdingFramework.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="DotNetZip" Version="1.13.8" />
     <PackageReference Include="HelixToolkit" Version="2.9.0" />
     <PackageReference Include="HelixToolkit.SharpDX.Core" Version="2.9.0" />
+    <PackageReference Include="Lumina" Version="2.5.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="SharpDX" Version="4.2.0" />
     <PackageReference Include="SharpDX.Mathematics" Version="4.2.0" />


### PR DESCRIPTION
This repository adds two new arguments, doLumina and luminaOutDir, to all write and copy operations, which allow files to be written out in a Lumina/Umbra/Penumbra compatible format.

In order to support this, Lumina was additionally added as a dependency.