### PR TITLE
Updates most reference packages to latest working versions

### DIFF
--- a/xivModdingFramework/xivModdingFramework.csproj
+++ b/xivModdingFramework/xivModdingFramework.csproj
@@ -22,8 +22,8 @@
 
   <ItemGroup>
     <PackageReference Include="DotNetZip" Version="1.15.0" />
-    <PackageReference Include="HelixToolkit" Version="2.11.0" />
-    <PackageReference Include="HelixToolkit.SharpDX.Core" Version="2.11.0" />
+    <PackageReference Include="HelixToolkit" Version="2.17.0" />
+    <PackageReference Include="HelixToolkit.SharpDX.Core" Version="2.17.0" />
     <PackageReference Include="Lumina" Version="3.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="SharpDX" Version="4.2.0" />

--- a/xivModdingFramework/xivModdingFramework.csproj
+++ b/xivModdingFramework/xivModdingFramework.csproj
@@ -22,8 +22,8 @@
 
   <ItemGroup>
     <PackageReference Include="DotNetZip" Version="1.15.0" />
-    <PackageReference Include="HelixToolkit" Version="2.9.0" />
-    <PackageReference Include="HelixToolkit.SharpDX.Core" Version="2.9.0" />
+    <PackageReference Include="HelixToolkit" Version="2.10.0" />
+    <PackageReference Include="HelixToolkit.SharpDX.Core" Version="2.10.0" />
     <PackageReference Include="Lumina" Version="3.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="SharpDX" Version="4.2.0" />

--- a/xivModdingFramework/xivModdingFramework.csproj
+++ b/xivModdingFramework/xivModdingFramework.csproj
@@ -21,18 +21,18 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotNetZip" Version="1.13.8" />
+    <PackageReference Include="DotNetZip" Version="1.15.0" />
     <PackageReference Include="HelixToolkit" Version="2.9.0" />
     <PackageReference Include="HelixToolkit.SharpDX.Core" Version="2.9.0" />
     <PackageReference Include="Lumina" Version="2.5.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="SharpDX" Version="4.2.0" />
     <PackageReference Include="SharpDX.Mathematics" Version="4.2.0" />
-    <PackageReference Include="System.Buffers" Version="4.5.0" />
+    <PackageReference Include="System.Buffers" Version="4.5.1" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0007" />
-    <PackageReference Include="System.Data.SQLite" Version="1.0.113.1" />
+    <PackageReference Include="System.Data.SQLite" Version="1.0.114.4" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
-    <PackageReference Include="TeximpNet" Version="1.4.1" />
+    <PackageReference Include="TeximpNet" Version="1.4.3" />
   </ItemGroup>
   
  <PropertyGroup> 

--- a/xivModdingFramework/xivModdingFramework.csproj
+++ b/xivModdingFramework/xivModdingFramework.csproj
@@ -22,8 +22,8 @@
 
   <ItemGroup>
     <PackageReference Include="DotNetZip" Version="1.15.0" />
-    <PackageReference Include="HelixToolkit" Version="2.10.0" />
-    <PackageReference Include="HelixToolkit.SharpDX.Core" Version="2.10.0" />
+    <PackageReference Include="HelixToolkit" Version="2.11.0" />
+    <PackageReference Include="HelixToolkit.SharpDX.Core" Version="2.11.0" />
     <PackageReference Include="Lumina" Version="3.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="SharpDX" Version="4.2.0" />

--- a/xivModdingFramework/xivModdingFramework.csproj
+++ b/xivModdingFramework/xivModdingFramework.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="DotNetZip" Version="1.15.0" />
     <PackageReference Include="HelixToolkit" Version="2.9.0" />
     <PackageReference Include="HelixToolkit.SharpDX.Core" Version="2.9.0" />
-    <PackageReference Include="Lumina" Version="2.5.1" />
+    <PackageReference Include="Lumina" Version="3.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="SharpDX" Version="4.2.0" />
     <PackageReference Include="SharpDX.Mathematics" Version="4.2.0" />


### PR DESCRIPTION
MahApps/ControlzEx has breaking changes so wasn't touched

SixLabors removed IsDisposed and GetSinglePixel() so wasn't touched (updated by Kora in #33)