### PR TITLE
Add common Linux Drive Formats

### DIFF
--- a/xivModdingFramework/SqPack/FileTypes/Dat.cs
+++ b/xivModdingFramework/SqPack/FileTypes/Dat.cs
@@ -93,6 +93,20 @@ namespace xivModdingFramework.SqPack.FileTypes
                     return 34359738368;
                 case "exFAT":
                     return 34359738368;
+                case "ext2":
+                    return 34359738368;
+                case "ext3":
+                    return 34359738368;
+                case "ext4":
+                    return 34359738368;
+                case "XFS":
+                    return 34359738368;
+                case "btrfs":
+                    return 34359738368;
+                case "ZFS":
+                    return 34359738368;
+                case "ReiserFS":
+                    return 34359738368;
                 default:
                     // Unknown HDD Format, default to the basic limit.
                     return 2000000000;


### PR DESCRIPTION
Adds ext2, ext3, ext4, XFS, btrfs, ZFS, ReiserFS as all support large files.

The exact set values are smaller than the actually supported file size in most of the systems. In certain cases it also depends on block sizes, but these should be safe.