### PR TITLE
Fix the model preview not always rendering parts assigned to row 0

### DIFF
--- a/xivModdingFramework/Models/ModelTextures/ModelTexture.cs
+++ b/xivModdingFramework/Models/ModelTextures/ModelTexture.cs
@@ -414,9 +414,18 @@ namespace xivModdingFramework.Models.ModelTextures
                     using (var img = Image.LoadPixelData<Rgba32>(texMapData.Normal.Data, texMapData.Normal.Width,
                         texMapData.Normal.Height))
                     {
-                        img.Mutate(x => x.Resize(width, height));
+                        // ImageSharp pre-multiplies the RGB by the alpha component during resize, if alpha is 0 (colourset row 0)
+                        // this ends up causing issues and destroying the RGB values resulting in an invisible preview model
+                        // https://github.com/SixLabors/ImageSharp/issues/1498#issuecomment-757519563
+                        img.Mutate(x => x.Resize(
+                            new ResizeOptions
+                            {
+                                Size = new Size(width, height),
+                                PremultiplyAlpha = false
+                            })
+                        );
 
-                        texMapData.Normal.Data = MemoryMarshal.AsBytes(img.GetPixelSpan()).ToArray();
+                        texMapData.Normal.Data = MemoryMarshal.AsBytes(img.GetPixelMemoryGroup()[0].Span).ToArray();
                     }
                 }
 
@@ -436,7 +445,7 @@ namespace xivModdingFramework.Models.ModelTextures
                         }
                         img.Mutate(x => x.Resize(width, height));
 
-                        texMapData.Diffuse.Data = MemoryMarshal.AsBytes(img.GetPixelSpan()).ToArray();
+                        texMapData.Diffuse.Data = MemoryMarshal.AsBytes(img.GetPixelMemoryGroup()[0].Span).ToArray();
                     }
                 }
 
@@ -448,7 +457,7 @@ namespace xivModdingFramework.Models.ModelTextures
                     {
                         img.Mutate(x => x.Resize(width, height));
 
-                        texMapData.Specular.Data = MemoryMarshal.AsBytes(img.GetPixelSpan()).ToArray();
+                        texMapData.Specular.Data = MemoryMarshal.AsBytes(img.GetPixelMemoryGroup()[0].Span).ToArray();
                     }
                 }
             });

--- a/xivModdingFramework/Textures/FileTypes/Tex.cs
+++ b/xivModdingFramework/Textures/FileTypes/Tex.cs
@@ -619,14 +619,14 @@ namespace xivModdingFramework.Textures.FileTypes
                         {
                             for (var x = 0; x < width; x++)
                             {
-                                var red = br.ReadByte();
-                                var green = br.ReadByte();
                                 var blue = br.ReadByte();
+                                var green = br.ReadByte();
+                                var red = br.ReadByte();
                                 var alpha = br.ReadByte();
 
-                                convertedBytes.Add(blue);
-                                convertedBytes.Add(green);
                                 convertedBytes.Add(red);
+                                convertedBytes.Add(green);
+                                convertedBytes.Add(blue);
                                 convertedBytes.Add(alpha);
                             }
                         }

--- a/xivModdingFramework/xivModdingFramework.csproj
+++ b/xivModdingFramework/xivModdingFramework.csproj
@@ -28,8 +28,8 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="SharpDX" Version="4.2.0" />
     <PackageReference Include="SharpDX.Mathematics" Version="4.2.0" />
-    <PackageReference Include="System.Buffers" Version="4.5.0" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0007" />
+    <PackageReference Include="System.Buffers" Version="4.5.1" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.3" />
     <PackageReference Include="System.Data.SQLite" Version="1.0.113.1" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
     <PackageReference Include="TeximpNet" Version="1.4.1" />


### PR DESCRIPTION
With 4k texture maps or when map sizes differed from one another the model preview wouldn't render parts of the model that were assigned to colourset row 0. This ended up being due to ImageSharp premultiplying the RGB component by the alpha component which in this case meant a multiplication by 0. As a result the RGB values for the pixels of the normal map with an alpha of 0 ended up as (0,0,0) as well.

Related issue: https://github.com/SixLabors/ImageSharp/issues/1498#issuecomment-757519563

Changes:
- Updated ImageSharp from 1.0.0-beta0007 to 1.0.3 to allow us to opt out of premultiplying the RGB by the alpha component.
- Fixed some breaking changes due to the update
  - `Image.GetPixelSpan` was removed
  - `Image.IsDisposed` was made private