### PR TITLE
Use cached index files when loading eqp/eqdp/est/gmp files

### DIFF
--- a/xivModdingFramework/Models/FileTypes/Eqp.cs
+++ b/xivModdingFramework/Models/FileTypes/Eqp.cs
@@ -127,7 +127,7 @@ namespace xivModdingFramework.Models.FileTypes
                 }
             }
 
-            var file = (await LoadGimmickParameterFile(false));
+            var file = await LoadGimmickParameterFile(false, cachedIndexFile);
 
 
             var offsets = new Dictionary<uint, int>();
@@ -259,9 +259,9 @@ namespace xivModdingFramework.Models.FileTypes
         {
             await _dat.ImportType2Data(bytes, GimmickParameterFile, Constants.InternalModSourceName, referenceItem, cachedIndexFile, cachedModList);
         }
-        private async Task<byte[]> LoadGimmickParameterFile(bool forceDefault = false)
+        private async Task<byte[]> LoadGimmickParameterFile(bool forceDefault = false, IndexFile cachedIndexFile = null)
         {
-            return await _dat.GetType2Data(GimmickParameterFile, forceDefault);
+            return await _dat.GetType2Data(GimmickParameterFile, forceDefault, cachedIndexFile);
         }
 
         /// <summary>
@@ -282,7 +282,7 @@ namespace xivModdingFramework.Models.FileTypes
                 }
             }
 
-            var file = (await LoadEquipmentParameterFile(false));
+            var file = await LoadEquipmentParameterFile(false, cachedIndexFile);
 
 
             var offsets = new Dictionary<uint, int>();
@@ -505,9 +505,9 @@ namespace xivModdingFramework.Models.FileTypes
         /// Gets the raw equipment parameter file.
         /// </summary>
         /// <returns></returns>
-        private async Task<byte[]> LoadEquipmentParameterFile(bool forceDefault = false)
+        private async Task<byte[]> LoadEquipmentParameterFile(bool forceDefault = false, IndexFile cachedIndexFile = null)
         {
-            return await _dat.GetType2Data(EquipmentParameterFile, forceDefault);
+            return await _dat.GetType2Data(EquipmentParameterFile, forceDefault, cachedIndexFile);
         }
 
 
@@ -730,7 +730,7 @@ namespace xivModdingFramework.Models.FileTypes
             {
                 var race = raceKv.Key;
                 var fileName = EquipmentDeformerParameterRootPath + "c" + race.GetRaceCode() + "." + EquipmentDeformerParameterExtension;
-                var data = await LoadEquipmentDeformationFile(race, false, false);
+                var data = await LoadEquipmentDeformationFile(race, false, false, cachedIndexFile);
 
                 // Loop through until we've expanded all of the data entries that we need in order to write the data.
                 bool clean = false;
@@ -1224,11 +1224,11 @@ namespace xivModdingFramework.Models.FileTypes
         /// Gets the raw equipment or accessory deformation parameters file for a given race.
         /// </summary>
         /// <returns></returns>
-        private async Task<byte[]> LoadEquipmentDeformationFile(XivRace race, bool accessory = false, bool forceDefault = false)
+        private async Task<byte[]> LoadEquipmentDeformationFile(XivRace race, bool accessory = false, bool forceDefault = false, IndexFile cachedIndexFile = null)
         {
             var rootPath = accessory ? AccessoryDeformerParameterRootPath : EquipmentDeformerParameterRootPath;
             var fileName = rootPath + "c" + race.GetRaceCode() + "." + EquipmentDeformerParameterExtension;
-            return await _dat.GetType2Data(fileName, forceDefault);
+            return await _dat.GetType2Data(fileName, forceDefault, cachedIndexFile);
         }
 
         /// <summary>

--- a/xivModdingFramework/Models/FileTypes/Est.cs
+++ b/xivModdingFramework/Models/FileTypes/Est.cs
@@ -169,7 +169,7 @@ namespace xivModdingFramework.Models.FileTypes
         /// <returns></returns>
         public static async Task SaveExtraSkeletonEntries(EstType type, List<ExtraSkeletonEntry> modifiedEntries, IItem referenceItem = null, IndexFile cachedIndexFile = null, ModList cachedModList = null)
         {
-            var entries = await GetEstFile(type, false);
+            var entries = await GetEstFile(type, false, cachedIndexFile);
 
             // Add/Remove entries.
             foreach (var entry in modifiedEntries)
@@ -316,10 +316,10 @@ namespace xivModdingFramework.Models.FileTypes
             return entries[race][setId];
         }
 
-        private static async Task<Dictionary<XivRace, Dictionary<ushort, ExtraSkeletonEntry>>> GetEstFile(EstType type, bool forceDefault = false)
+        private static async Task<Dictionary<XivRace, Dictionary<ushort, ExtraSkeletonEntry>>> GetEstFile(EstType type, bool forceDefault = false, IndexFile cachedIndexFile = null)
         {
             var _dat = new Dat(_gameDirectory);
-            var data = await _dat.GetType2Data(EstFiles[type], forceDefault);
+            var data = await _dat.GetType2Data(EstFiles[type], forceDefault, cachedIndexFile);
 
             var count = BitConverter.ToUInt32(data, 0);
 

--- a/xivModdingFramework/Mods/FileTypes/TTMP.cs
+++ b/xivModdingFramework/Mods/FileTypes/TTMP.cs
@@ -895,7 +895,6 @@ namespace xivModdingFramework.Mods.FileTypes
                                 {
                                     var oldOffset = originalIndexFiles[df].Get8xDataOffset(file);
                                     modifiedIndexFiles[df].SetDataOffset(file, oldOffset);
-
                                 }
                             }
                         }

--- a/xivModdingFramework/Mods/RootCloner.cs
+++ b/xivModdingFramework/Mods/RootCloner.cs
@@ -413,10 +413,6 @@ namespace xivModdingFramework.Mods
                 // Save the new Metadata file via the batch function so that it's only written to the memory cache for now.
                 await ItemMetadata.ApplyMetadataBatched(new List<ItemMetadata>() { newMetadata }, index, modlist, false);
 
-                
-
-
-
                 if (ProgressReporter != null)
                 {
                     ProgressReporter.Report("Filling in missing material sets...");


### PR DESCRIPTION
Users have been reporting metadata being incorrect after importing a modpack and choosing new items as the mod destination. I wasn't able to figure out how to reproduce it as any attempt seemingly worked fine until Titan figured out that it was occurring when choosing multiple new items of the same set. 

The cause of the metadata seemingly not being moved properly is that the eqp/eqdp/est/gmp files are being read while using the non-cached index files. As a result any changes from previously cloned item in the same set aren't yet applied and get overwritten.

Modpack used to reproduce: https://www.patreon.com/posts/58549849

Steps:
1. Import modpack, leave all options as default
2. When given the choice of choosing new items, change the destination item from `Sailor Shirt` to `Expeditioner's Tabard` and `Sailor Deck Shoes` to `Expeditioner's Thighboots`
3. Load the `Expeditioner's Thighboots`

Expected result: 
![image](https://user-images.githubusercontent.com/59175928/151726187-35ba3ada-33ba-4d9d-a5fa-66598657398d.png)
Actual result:
![image](https://user-images.githubusercontent.com/59175928/151726369-f4aee51b-9ef1-4e9b-82f9-73d1338df769.png)