### PR TITLE
Reverts changes to OutdoorModelNumberOffsetByPatch, and changes the m…

### DIFF
--- a/xivModdingFramework/Items/Categories/Housing.cs
+++ b/xivModdingFramework/Items/Categories/Housing.cs
@@ -81,7 +81,6 @@ namespace xivModdingFramework.Items.Categories
         private static Dictionary<string, int> OutdoorModelNumberOffsetByPatch = new Dictionary<string, int>()
         {
             { "5.5", 12 },
-            { "6.1", 13 },
         };
         private static Dictionary<string, int> OutdoorItemCategoryOffestByPatch = new Dictionary<string, int>()
         {
@@ -283,7 +282,7 @@ namespace xivModdingFramework.Items.Categories
             // These will need to be changed if data gets added or removed with a patch
 
             int itemIndexOffset = 10;
-            int modelNumberOffset = OutdoorModelNumberOffsetByPatch["6.1"];
+            int modelNumberOffset = OutdoorModelNumberOffsetByPatch["5.5"];
             int itemCategoryOffset = OutdoorItemCategoryOffestByPatch["6.1"];
 
             const int itemNameDataOffset = 14;
@@ -326,7 +325,7 @@ namespace xivModdingFramework.Items.Categories
                     var itemIndex = br.ReadUInt16();
 
                     br.BaseStream.Seek(modelNumberOffset, SeekOrigin.Begin);
-                    item.ModelInfo.PrimaryID = br.ReadByte();
+                    item.ModelInfo.PrimaryID = br.ReadInt16();
 
                     br.BaseStream.Seek(itemCategoryOffset, SeekOrigin.Begin);
                     var housingCategory = br.ReadByte();


### PR DESCRIPTION
…odelNumberOffset to a signed 16bit int

Outdoor furniture modelNumberOffset was erroneously cast as ReadByte, which caused the unchanged Offset:12 value to throw errors after 6.1,  with this change it is a 16bit Signed Int and the offset reverted to 12.

Corrects issue with the Outdoor furniture list throwing the wrong model for 6.1 items, and the item set list no longer shows the wrong names attached to items below 255, now showing them correctly on items above 255.

![image](https://user-images.githubusercontent.com/1098176/187076802-9acbf8c5-d28a-4aa1-b3c9-31278e8fd3cb.png)
