### PR TITLE
texconv/tga fixes

### DIFF
--- a/xivModdingFramework/Textures/FileTypes/DDS.cs
+++ b/xivModdingFramework/Textures/FileTypes/DDS.cs
@@ -852,7 +852,7 @@ namespace xivModdingFramework.Textures.FileTypes
                     Directory.CreateDirectory(tmpDir);
                     var outTemp = Path.Combine(tmpDir, output);
 
-                    var args = $"{formatArg} {mipArg} -tgazeroalpha -sepalpha -y {input}";
+                    var args = $"{formatArg} {mipArg} -bc q -tgazeroalpha -sepalpha -y {input}";
 
                     var proc = new Process
                     {

--- a/xivModdingFramework/Textures/FileTypes/DDS.cs
+++ b/xivModdingFramework/Textures/FileTypes/DDS.cs
@@ -809,6 +809,7 @@ namespace xivModdingFramework.Textures.FileTypes
             using (var img = Image.LoadPixelData<Rgba32>(rgbaData, width, height))
             {
                 var encoder = new TgaEncoder();
+                encoder.Compression = TgaCompression.None;
                 encoder.BitsPerPixel = TgaBitsPerPixel.Pixel32;
                 img.SaveAsTga(input,encoder);
             }

--- a/xivModdingFramework/Textures/FileTypes/DDS.cs
+++ b/xivModdingFramework/Textures/FileTypes/DDS.cs
@@ -803,7 +803,9 @@ namespace xivModdingFramework.Textures.FileTypes
         /// <returns></returns>
         public static async Task<string> TexConv(byte[] rgbaData, int width, int height, string format, bool generateMipMaps = false)
         {
-            var input = Path.Combine(IOUtil.GetFrameworkTempFolder(), Guid.NewGuid().ToString() + ".tga");
+            var tmpDir = IOUtil.GetFrameworkTempFolder();
+            Directory.CreateDirectory(tmpDir);
+            var input = Path.Combine(tmpDir, Guid.NewGuid().ToString() + ".tga");
             using (var img = Image.LoadPixelData<Rgba32>(rgbaData, width, height))
             {
                 var encoder = new TgaEncoder();
@@ -845,7 +847,9 @@ namespace xivModdingFramework.Textures.FileTypes
                 {
 
                     var outFile = Path.Combine(workingDirectory, output);
-                    var outTemp = Path.Combine(IOUtil.GetFrameworkTempFolder(), output);
+                    var tmpDir = IOUtil.GetFrameworkTempFolder();
+                    Directory.CreateDirectory(tmpDir);
+                    var outTemp = Path.Combine(tmpDir, output);
 
                     var args = $"{formatArg} {mipArg} -sepalpha -y {input}";
 

--- a/xivModdingFramework/Textures/FileTypes/DDS.cs
+++ b/xivModdingFramework/Textures/FileTypes/DDS.cs
@@ -852,7 +852,7 @@ namespace xivModdingFramework.Textures.FileTypes
                     Directory.CreateDirectory(tmpDir);
                     var outTemp = Path.Combine(tmpDir, output);
 
-                    var args = $"{formatArg} {mipArg} -sepalpha -y {input}";
+                    var args = $"{formatArg} {mipArg} -tgazeroalpha -sepalpha -y {input}";
 
                     var proc = new Process
                     {


### PR DESCRIPTION
1) Ensure temp directory exists before attempting to use it.

2) RLE encoding in ImageSharp 2.x branch is entirely broken and needs to be disabled to prevent TexConv from exploding. It also produces files that are bigger than uncompressed so there's https://github.com/TexTools/FFXIV_TexTools_UI/pull/293 as well to go with it.

3) **-tgazeroalpha** flag is documented here: https://github.com/microsoft/DirectXTex/wiki/Texconv -- prevents texconv from assuming an all-zero alpha channel in a TGA file should be treated as all-ones

4) The final commit in this PR is "Faster BC7 encoding". For my single test image it was approximately 100x faster when doing CPU encoding for an identical compressed output size, but you might not want to use it if you find a case where it sucks or something.

BC7 encoding with the slow setting seemed to use something like 6 minutes of CPU time to encode a 1024x512 texture.