### PR TITLE
Return a UV mode for model preview textures

### DIFF
--- a/xivModdingFramework/Models/DataContainers/ModelTextureData.cs
+++ b/xivModdingFramework/Models/DataContainers/ModelTextureData.cs
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 using xivModdingFramework.Helpers;
+using xivModdingFramework.Materials.DataContainers;
 using xivModdingFramework.Materials.FileTypes;
 using xivModdingFramework.Models.Helpers;
 
@@ -56,6 +57,8 @@ namespace xivModdingFramework.Models.DataContainers
         }
 
         public bool RenderBackfaces { get; set; }
+        public TextureSampler.ETilingMode UTilingMode { get; set; }
+        public TextureSampler.ETilingMode VTilingMode { get; set; }
     }
     /// <summary>
     /// This class holds the data for the textures to be used on the 3D Model

--- a/xivModdingFramework/Models/ModelTextures/ModelTexture.cs
+++ b/xivModdingFramework/Models/ModelTextures/ModelTexture.cs
@@ -268,6 +268,12 @@ namespace xivModdingFramework.Models.ModelTextures
                 result.RenderBackfaces = true;
             }
 
+            if (mtrl.Textures.Count > 0)
+            {
+                result.UTilingMode = mtrl.Textures[0].Sampler.UTilingMode;
+                result.VTilingMode = mtrl.Textures[0].Sampler.VTilingMode;
+            }
+
             var settings = new ShaderMapperSettings()
             {
                 HighlightedRow = highlightedRow,


### PR DESCRIPTION
Helps expose UV errors before making it all the way in to the game.

Assumption is made that the mode of the first texture in a material will relevant in determining which mode to use for the actual render preview.

I looked at a lot of faces, monsters and equipment which all primarily use Mirror mode for all textures except Index, and I didn't see any visual defects caused by this.

I think ideally this logic would use a priority like Diffuse > Specular/Mask > other. A lot of equipment has Normal as its first texture.