### PR TITLE
Fix IMC options not changing default values

### DIFF
--- a/xivModdingFramework/Mods/FileTypes/PMP.cs
+++ b/xivModdingFramework/Mods/FileTypes/PMP.cs
@@ -398,7 +398,7 @@ namespace xivModdingFramework.Mods.FileTypes.PMP
                                 var opt = group.Options[i] as PmpImcOptionJson;
                                 optionIdx++;
 
-                                xivImc.AttributeMask |= opt.AttributeMask;
+                                xivImc.AttributeMask ^= opt.AttributeMask;
                             }
                         }
 


### PR DESCRIPTION
Currently, default IMC options cannot be toggled off on import.

If the default options are 0111 (A, B, C enabled, D disabled), then disabling C and enabling D will apply a bitmask of 1100.

Using bitwise OR (0111 | 1100) results in 1111 (D enabled but C still enabled). Using bitwise XOR (0111 ^ 1100) gives the correct result of 1011 (D enabled and C disabled).