### PR TITLE
PMP stuffs

### DIFF
--- a/xivModdingFramework/Mods/FileTypes/PMP.cs
+++ b/xivModdingFramework/Mods/FileTypes/PMP.cs
@@ -350,18 +350,19 @@ namespace xivModdingFramework.Mods.FileTypes.PMP
                     var selected = group.DefaultSettings;
 
                     // If the user selected custom settings, use those.
-                    if (group.SelectedSettings >= 0)
+                    if (group.SelectedSettings.HasValue)
                     {
-                        selected = group.SelectedSettings;
+                        selected = group.SelectedSettings.Value;
                     }
 
                     if (group.Type == "Single")
                     {
-                        if (selected < 0 || selected >= group.Options.Count)
+                        var selectedIdx = (int)selected;
+                        if (selected < 0 || selectedIdx >= group.Options.Count)
                         {
                             selected = 0;
                         }
-                        var groupRes = await ImportOption(group.Options[selected], unzippedPath, tx, progress, groupIdx, optionIdx);
+                        var groupRes = await ImportOption(group.Options[selectedIdx], unzippedPath, tx, progress, groupIdx, optionIdx);
                         UnionDict(imported, groupRes.Imported);
                         notImported.UnionWith(groupRes.NotImported);
                     }
@@ -373,7 +374,7 @@ namespace xivModdingFramework.Mods.FileTypes.PMP
                         foreach(var op in ordered)
                         {
                             var i = group.Options.IndexOf(op);
-                            var value = 1 << i;
+                            var value = 1UL << i;
                             if ((selected & value) > 0)
                             {
                                 var groupRes = await ImportOption(group.Options[i], unzippedPath, tx, progress, groupIdx, optionIdx);
@@ -393,7 +394,7 @@ namespace xivModdingFramework.Mods.FileTypes.PMP
                         // Bitmask options.
                         for (int i = 0; i < group.Options.Count; i++)
                         {
-                            var value = 1 << i;
+                            var value = 1UL << i;
                             if ((selected & value) > 0)
                             {
                                 var disableOpt = group.Options[i] as PmpDisableImcOptionJson;
@@ -1334,10 +1335,10 @@ namespace xivModdingFramework.Mods.FileTypes.PMP
         public string Type = "";
 
         // Only used internally when the user is selecting options during install/application.
-        [JsonIgnore] public int SelectedSettings = -1;
+        [JsonIgnore] public ulong? SelectedSettings = null;
 
         // Either single Index or Bitflag.
-        public int DefaultSettings;
+        public ulong DefaultSettings;
         
         public List<PMPOptionJson> Options = new List<PMPOptionJson>();
     }

--- a/xivModdingFramework/Mods/FileTypes/PMP.cs
+++ b/xivModdingFramework/Mods/FileTypes/PMP.cs
@@ -116,13 +116,19 @@ namespace xivModdingFramework.Mods.FileTypes.PMP
             var metaPath = Path.Combine(path, "meta.json");
 
             var text = File.ReadAllText(metaPath);
-            var meta = JsonConvert.DeserializeObject<PMPMetaJson>(text);
+            var meta = JsonConvert.DeserializeObject<PMPMetaJson>(text, new JsonSerializerSettings
+            {
+                NullValueHandling = NullValueHandling.Ignore
+            });
 
             string image = null;
 
 
 
-            var defaultOption = JsonConvert.DeserializeObject<PMPOptionJson>(File.ReadAllText(defModPath));
+            var defaultOption = JsonConvert.DeserializeObject<PMPOptionJson>(File.ReadAllText(defModPath), new JsonSerializerSettings
+            {
+                NullValueHandling = NullValueHandling.Ignore
+            });
 
             var groups = new List<PMPGroupJson>();
 
@@ -132,7 +138,10 @@ namespace xivModdingFramework.Mods.FileTypes.PMP
             {
                 if (Path.GetFileName(file).StartsWith("group_") && Path.GetFileName(file).ToLower().EndsWith(".json"))
                 {
-                    var group = JsonConvert.DeserializeObject<PMPGroupJson>(File.ReadAllText(file));
+                    var group = JsonConvert.DeserializeObject<PMPGroupJson>(File.ReadAllText(file), new JsonSerializerSettings
+                    {
+                        NullValueHandling = NullValueHandling.Ignore
+                    });
                     if (group != null)
                     {
                         groups.Add(group);
@@ -1300,12 +1309,12 @@ namespace xivModdingFramework.Mods.FileTypes.PMP
     public class PMPMetaJson
     {
         public int FileVersion;
-        public string Name;
-        public string Author;
-        public string Description;
-        public string Version;
-        public string Website;
-        public string Image;
+        public string Name = "";
+        public string Author = "";
+        public string Description = "";
+        public string Version = "";
+        public string Website = "";
+        public string Image = "";
 
         // These exist.
         public List<string> ModTags;
@@ -1315,14 +1324,14 @@ namespace xivModdingFramework.Mods.FileTypes.PMP
     [JsonSubtypes.KnownSubType(typeof(PMPImcGroupJson), "Imc")]
     public class PMPGroupJson
     {
-        public string Name;
-        public string Description;
+        public string Name = "";
+        public string Description = "";
         public int Priority;
-        public string Image;
+        public string Image = "";
         public int Page;
 
         // "Multi", "Single", or "Imc"
-        public string Type;
+        public string Type = "";
 
         // Only used internally when the user is selecting options during install/application.
         [JsonIgnore] public int SelectedSettings = -1;
@@ -1335,8 +1344,8 @@ namespace xivModdingFramework.Mods.FileTypes.PMP
 
     public class PMPImcGroupJson : PMPGroupJson
     {
-        public PMPImcManipulationJson.PMPImcEntry DefaultEntry;
         public PmpIdentifierJson Identifier;
+        public PMPImcManipulationJson.PMPImcEntry DefaultEntry;
         public bool AllVariants;
         public bool OnlyAttributes;
 
@@ -1387,22 +1396,22 @@ namespace xivModdingFramework.Mods.FileTypes.PMP
     }
 
     [JsonConverter(typeof(JsonSubtypes))]
-    [JsonSubtypes.KnownSubTypeWithProperty(typeof(PmpStandardOptionJson), "Files")]
+    [JsonSubtypes.FallBackSubType(typeof(PmpStandardOptionJson))]
     [JsonSubtypes.KnownSubTypeWithProperty(typeof(PmpDisableImcOptionJson), "IsDisableSubMod")]
     [JsonSubtypes.KnownSubTypeWithProperty(typeof(PmpImcOptionJson), "AttributeMask")]
     public class PMPOptionJson
     {
-        public string Name;
-        public string Description;
-        public string Image;
+        public string Name = "";
+        public string Description = "";
+        public string Image = "";
     }
 
     public class PmpStandardOptionJson : PMPOptionJson
     {
-        public Dictionary<string, string> Files;
-        public Dictionary<string, string> FileSwaps;
-        public List<PMPManipulationWrapperJson> Manipulations;
-        public int Priority;
+        public int Priority = 0;
+        public Dictionary<string, string> Files = new();
+        public Dictionary<string, string> FileSwaps = new();
+        public List<PMPManipulationWrapperJson> Manipulations = new();
 
         [JsonIgnore] public bool IsEmptyOption => !(
             (FileSwaps != null && FileSwaps.Count > 0) ||

--- a/xivModdingFramework/Mods/FileTypes/PmpManipulation.cs
+++ b/xivModdingFramework/Mods/FileTypes/PmpManipulation.cs
@@ -345,10 +345,10 @@ namespace xivModdingFramework.Mods.FileTypes
             }
         }
         public PMPImcEntry Entry;
+        public PMPObjectType ObjectType;
         public uint PrimaryId;
         public uint SecondaryId;
         public uint Variant;
-        public PMPObjectType ObjectType;
         public PMPEquipSlot EquipSlot;
         public PMPObjectType BodySlot;
 

--- a/xivModdingFramework/Mods/FileTypes/PmpManipulation.cs
+++ b/xivModdingFramework/Mods/FileTypes/PmpManipulation.cs
@@ -315,7 +315,7 @@ namespace xivModdingFramework.Mods.FileTypes
             public byte VfxId;
             public byte MaterialAnimationId;
 
-            // Are these redundantly stored?
+            [JsonIgnore]
             public ushort AttributeAndSound;
             public ushort AttributeMask;
             public byte SoundId;
@@ -432,6 +432,7 @@ namespace xivModdingFramework.Mods.FileTypes
         public uint SetId;
         public PMPEquipSlot Slot;
 
+        [JsonIgnore]
         public ushort ShiftedEntry
         {
             get

--- a/xivModdingFramework/Mods/WizardData.cs
+++ b/xivModdingFramework/Mods/WizardData.cs
@@ -569,7 +569,7 @@ namespace xivModdingFramework.Mods
         internal string FolderPath;
 
         // Int or Bitflag depending on OptionType.
-        public int Selection
+        public ulong Selection
         {
             get
             {
@@ -580,18 +580,17 @@ namespace xivModdingFramework.Mods
                     {
                         return 0;
                     }
-                    return Options.IndexOf(op);
+                    return (ulong)Options.IndexOf(op);
                 }
                 else
                 {
-                    var total = 0;
+                    ulong total = 0;
                     for (int i = 0; i < Options.Count; i++)
                     {
                         if (Options[i].Selected)
                         {
-                            uint mask = 1;
-                            uint shifted = mask << i;
-                            total |= (int)shifted;
+                            var bit = 1UL << i;
+                            total |= bit;
                         }
                     }
                     return total;
@@ -796,11 +795,11 @@ namespace xivModdingFramework.Mods
 
                 if (group.OptionType == EOptionType.Single)
                 {
-                    wizOp.Selected = pGroup.DefaultSettings == idx;
+                    wizOp.Selected = pGroup.DefaultSettings == (ulong)idx;
                 }
                 else
                 {
-                    var bit = 1 << idx;
+                    var bit = 1UL << idx;
                     wizOp.Selected = (pGroup.DefaultSettings & bit) != 0;
                 }
                 group.Options.Add(wizOp);

--- a/xivModdingFramework/Mods/WizardData.cs
+++ b/xivModdingFramework/Mods/WizardData.cs
@@ -221,9 +221,9 @@ namespace xivModdingFramework.Mods
     /// </summary>
     public class WizardOptionEntry : INotifyPropertyChanged
     {
-        public string Name { get; set; }
-        public string Description { get; set; }
-        public string Image { get; set; }
+        public string Name { get; set; } = "";
+        public string Description { get; set; } = "";
+        public string Image { get; set; } = "";
         internal string FolderPath { get; set; }
 
         public string NoDataIndicator
@@ -518,7 +518,6 @@ namespace xivModdingFramework.Mods
                 {
                     var io = new PmpDisableImcOptionJson();
                     op = io;
-                    io.IsDisableSubMod = true;
                 }
                 else
                 {
@@ -526,17 +525,29 @@ namespace xivModdingFramework.Mods
                     op = io;
                     io.AttributeMask = ImcData.AttributeMask;
                 }
-                op.Name = Name;
-                op.Description = Description;
             }
             else
             {
+                PmpStandardOptionJson so;
+
+                if (OptionType == EOptionType.Multi)
+                {
+                    var mo = new PmpMultiOptionJson();
+                    so = mo;
+                    mo.Priority = StandardData.Priority;
+                }
+                else
+                {
+                    so = new PmpSingleOptionJson();
+                }
                 // This unpacks our deduplicated files as needed.
-                op = await PMP.CreatePmpStandardOption(tempFolder, Name, Description, identifiers, StandardData.Manipulations, null, StandardData.Priority);
+                await PMP.PopulatePmpStandardOption(so, tempFolder, identifiers, StandardData.Manipulations);
+                op = so;
             }
 
+            op.Name = Name ?? "";
+            op.Description = Description ?? "";
             op.Image = WizardHelpers.WriteImage(Image, tempFolder, imageName);
-
 
             return op;
         }
@@ -562,9 +573,9 @@ namespace xivModdingFramework.Mods
     /// </summary>
     public class WizardGroupEntry
     {
-        public string Name;
-        public string Description;
-        public string Image;
+        public string Name = "";
+        public string Description = "";
+        public string Image = "";
 
         internal string FolderPath;
 
@@ -809,10 +820,10 @@ namespace xivModdingFramework.Mods
                     var data = await PMP.UnpackPmpOption(o, null, unzipPath, false);
                     wizOp.StandardData.Files = data.Files;
                     wizOp.StandardData.Manipulations = data.OtherManipulations;
-                    var sop = o as PmpStandardOptionJson;
-                    if (sop != null)
+                    var mop = o as PmpMultiOptionJson;
+                    if (mop != null)
                     {
-                        wizOp.StandardData.Priority = sop.Priority;
+                        wizOp.StandardData.Priority = mop.Priority;
                     }
 
                 }
@@ -886,7 +897,10 @@ namespace xivModdingFramework.Mods
 
         public async Task<PMPGroupJson> ToPmpGroup(string tempFolder, Dictionary<string, List<FileIdentifier>> identifiers, int page, bool oneOption = false)
         {
-            var pg = new PMPGroupJson();
+            PMPGroupJson pg;
+            // We want to insert a type-erased PMPOptionJson, as returned by ToPmpOption(), in to a type-erased PMPGroupJson
+            // This is the alternative to creating a single-purpose virtual function on PMPGroupJson
+            Action<PMPOptionJson> addOptionFn;
 
             if (this.ImcData != null)
             {
@@ -898,21 +912,25 @@ namespace xivModdingFramework.Mods
                 imcG.DefaultEntry = PMPImcManipulationJson.PMPImcEntry.FromXivImc(ImcData.BaseEntry);
                 imcG.AllVariants = ImcData.AllVariants;
                 imcG.OnlyAttributes = ImcData.OnlyAttributes;
+                addOptionFn = (PMPOptionJson o) => imcG.OptionData.Add((PmpImcOptionJson)o);
             }
             else
             {
-                pg.Type = OptionType.ToString();
+                if (this.OptionType == EOptionType.Multi)
+                {
+                    var mg = new PMPMultiGroupJson();
+                    pg = mg;
+                    pg.Type = "Multi";
+                    addOptionFn = (PMPOptionJson o) => mg.OptionData.Add((PmpMultiOptionJson)o);
+                }
+                else
+                {
+                    var sg = new PMPSingleGroupJson();
+                    pg = sg;
+                    pg.Type = "Single";
+                    addOptionFn = (PMPOptionJson o) => sg.OptionData.Add((PmpSingleOptionJson)o);
+                }
             }
-
-            pg.Name = Name.Trim();
-            pg.Description = Description;
-            pg.Options = new List<PMPOptionJson>();
-            pg.Priority = Priority;
-            pg.DefaultSettings = Selection;
-            pg.SelectedSettings = Selection;
-            pg.Page = page;
-
-            pg.Image = WizardHelpers.WriteImage(Image, tempFolder, IOUtil.MakePathSafe(Name));
 
             foreach (var option in Options)
             {
@@ -931,8 +949,17 @@ namespace xivModdingFramework.Mods
                 }
                 identifiers.TryGetValue(optionPrefix, out var files);
                 var opt = await option.ToPmpOption(tempFolder, files, imgName);
-                pg.Options.Add(opt);
+                addOptionFn(opt);
             }
+
+            pg.Name = (Name ?? "").Trim();
+            pg.Description = Description ?? "";
+            pg.Priority = Priority;
+            pg.DefaultSettings = Selection;
+            pg.SelectedSettings = Selection;
+            pg.Page = page;
+
+            pg.Image = WizardHelpers.WriteImage(Image, tempFolder, IOUtil.MakePathSafe(Name));
 
             return pg;
         }
@@ -1097,20 +1124,20 @@ namespace xivModdingFramework.Mods
             data.ModPack = mp;
             data.RawSource = pmp;
 
-            var defMod = pmp.DefaultMod as PmpStandardOptionJson;
-            if (defMod != null && !defMod.IsEmptyOption)
+            if (pmp.DefaultMod != null && !pmp.DefaultMod.IsEmptyOption)
             {
                 // Just drum up a basic group containing the default option.
-                var fakeGroup = new PMPGroupJson();
+                var fakeOption = new PmpSingleOptionJson();
+                fakeOption.Name = "Default";
+                fakeOption.Files = pmp.DefaultMod.Files;
+                fakeOption.FileSwaps = pmp.DefaultMod.FileSwaps;
+                fakeOption.Manipulations = pmp.DefaultMod.Manipulations;
+
+                var fakeGroup = new PMPSingleGroupJson();
                 fakeGroup.Name = "Default";
-                fakeGroup.Options = new List<PMPOptionJson>() { pmp.DefaultMod };
+                fakeGroup.OptionData = new List<PmpSingleOptionJson>() { fakeOption };
                 fakeGroup.SelectedSettings = 1;
                 fakeGroup.Type = "Single";
-
-                if (string.IsNullOrWhiteSpace(pmp.DefaultMod.Name))
-                {
-                    pmp.DefaultMod.Name = "Default";
-                }
 
                 var page = new WizardPageEntry();
                 page.Name = "Page 1";
@@ -1444,7 +1471,7 @@ namespace xivModdingFramework.Mods
             ClearNulls();
             var pmp = new PMPJson()
             {
-                DefaultMod = new PMPOptionJson(),
+                DefaultMod = new PmpDefaultMod(),
                 Groups = new List<PMPGroupJson>(),
                 Meta = new PMPMetaJson(),
             };
@@ -1527,11 +1554,28 @@ namespace xivModdingFramework.Mods
                 // their file identifier and internal path information
                 var identifiers = await FileIdentifier.IdentifierListFromDictionaries(allFiles);
 
+                bool defaultModOnly = false;
+
                 if (optionCount == 1)
                 {
-                    pmp.DefaultMod = (await DataPages.First(x => x.Groups.Count > 0).Groups.First(x => x.Options.Count > 0).ToPmpGroup(tempFolder, identifiers, 0, true)).Options[0];
+                    WizardGroupEntry firstGroup = DataPages.First(x => x.Groups.Count > 0)?.Groups?.First(x => x.Options.Count > 0);
+
+                    if (firstGroup != null && firstGroup.ImcData == null)
+                    {
+                        var sg = await firstGroup.ToPmpGroup(tempFolder, identifiers, 0, true);
+                        var so = sg.Options[0] as PmpStandardOptionJson;
+
+                        if (so != null)
+                        {
+                            pmp.DefaultMod.Files = so.Files;
+                            pmp.DefaultMod.FileSwaps = so.FileSwaps;
+                            pmp.DefaultMod.Manipulations = so.Manipulations;
+                            defaultModOnly = true;
+                        }
+                    }
                 }
-                else
+                
+                if (!defaultModOnly)
                 {
                     // This both constructs the JSON structure and writes our files to their
                     // real location in the folder tree in the temp folder.


### PR DESCRIPTION
Main motivation for this change is to give Penumbra the flexibility to omit fields without causing TexTools to choke ( https://github.com/xivdev/Penumbra/commit/bdc2da95c4ece4ce36b99fba9f1b9fea11b83251 ).

The class hierarchy for PMP types was re-structured a little to:
* make option parsing properly depend on the group type
* make the JSON output more consistent with Penumbra, and
* make room for implementing new mod group types (and cleanly fail when it encounters an unknown one)

I also put on big girl pants and just added a blatantly missing feature that synthesizes PMP default mod data using the opposite to what TexTools uses when reading PMP default mod data or TTMP Simple modpacks. -- That is: a group named "Default" with a single option named "Default" will transform in to the default mod.

I tested as best as I could: editing/installing/upgrading about half a dozen mods, using all of the modpack types, all of the penumbra features, and manually editing JSON files.