### PR TITLE
Fix Restore Mod Backup failing

### DIFF
--- a/xivModdingFramework/Helpers/IOUtil.cs
+++ b/xivModdingFramework/Helpers/IOUtil.cs
@@ -744,6 +744,11 @@ namespace xivModdingFramework.Helpers
             sourcePath = MakeLongPath(sourcePath);
             targetPath = MakeLongPath(targetPath);
 
+            // \\?\ prefixed Long File Names will fail if there's double slashes in a path
+            // Guarantee the source and target both have trailing slashes to avoid accidentally creating a double slash
+            if (!sourcePath.EndsWith("\\")) sourcePath += "\\";
+            if (!targetPath.EndsWith("\\")) targetPath += "\\";
+
             Directory.CreateDirectory(targetPath);
 
             //Now Create all of the directories
@@ -765,6 +770,8 @@ namespace xivModdingFramework.Helpers
         {
             if (!path.StartsWith("\\\\?\\"))
             {
+                while (path.Contains("\\\\"))
+                    path = path.Replace("\\\\", "\\");
                 path = "\\\\?\\" + path;
             }
             return path.Replace("/", "\\");


### PR DESCRIPTION
The CopyFolder() function used by the Restore Mod Backup function generates invalid path names and fails quite catastrophically.

This is now 2 out of 3 possible Long Path Name issues out of fixed.
Hopefully `/./` or `/../` never show up in any paths and break it again!

This actually fixes https://github.com/TexTools/FFXIV_TexTools_UI/issues/321 