### PR TITLE
Speed up model loading

### DIFF
--- a/xivModdingFramework/Models/FileTypes/Mdl.cs
+++ b/xivModdingFramework/Models/FileTypes/Mdl.cs
@@ -348,7 +348,6 @@ namespace xivModdingFramework.Models.FileTypes
 
         public static XivMdl GetXivMdl(byte[] mdlData, string mdlPath = "")
         {
-
             var xivMdl = new XivMdl { MdlPath = mdlPath };
             int totalNonNullMaterials = 0;
             var getShapeData = true;
@@ -1019,7 +1018,7 @@ namespace xivModdingFramework.Models.FileTypes
                 }
 
 
-                    var lodNum = 0;
+                var lodNum = 0;
                 var totalMeshNum = 0;
                 foreach (var lod in xivMdl.LoDList)
                 {
@@ -1031,16 +1030,12 @@ namespace xivModdingFramework.Models.FileTypes
                     {
                         throw new Exception("Failed to parse some meshes in previous LoD level.");
                     }
-
-                    // Seek to the start of the LoD.
-                    br.BaseStream.Seek(lod.VertexDataOffset, SeekOrigin.Begin);
-                    var LoDStart = br.BaseStream.Position;
                     
                     var mIdx = 0;
 
                     foreach (var meshData in meshDataList)
                     {
-                        MdlVertexReader.ReadVertexData(br, meshData, lod.VertexDataOffset, lod.IndexDataOffset);
+                        MdlVertexReader.ReadVertexData(mdlData, meshData, lod.VertexDataOffset, lod.IndexDataOffset);
 
                         mIdx++;
                         totalMeshNum++;

--- a/xivModdingFramework/Models/Helpers/ModelModifiers.cs
+++ b/xivModdingFramework/Models/Helpers/ModelModifiers.cs
@@ -421,7 +421,6 @@ namespace xivModdingFramework.Models.Helpers
 
                 for (var pi = 0; pi < totalParts; pi++)
                 {
-
                     var ttPart = new TTMeshPart();
                     ttMesh.Parts.Add(ttPart);
                     ttPart.Name = "Part " + partIdx;
@@ -431,24 +430,21 @@ namespace xivModdingFramework.Models.Helpers
                     var indexStart = fakePart == false ? basePart.IndexOffset - baseMesh.MeshInfo.IndexDataOffset : 0;
                     var indexCount = fakePart == false ? basePart.IndexCount : baseMesh.MeshInfo.IndexCount;
 
-                    var indices = baseMesh.VertexData.Indices.GetRange(indexStart, indexCount);
+                    var indices = baseMesh.VertexData.Indices.Skip(indexStart).Take(indexCount);
 
                     // Get the Vertices unique to this part.
-                    var uniqueVertexIdSet = new SortedSet<int>(indices); // Maximum possible amount is # of indices, though likely it is less.
-
-                    foreach (var ind in indices)
-                    {
-                        uniqueVertexIdSet.Add(ind);
-                    }
+                    var uniqueVertexIdSet = new HashSet<int>(indices);
 
                     // Need it as a list to have index access to it.
-                    var uniqueVertexIds = uniqueVertexIdSet.ToList();
+                    var uniqueVertexIds = new List<int>(uniqueVertexIdSet);
+                    uniqueVertexIds.Sort();
 
                     // Maps old vertex ID to new vertex ID.
-                    var vertDict = new Dictionary<int, int>(uniqueVertexIds.Count);
+                    var vertMap = new int[uniqueVertexIds.Max() + 1];
 
                     // Now we need to loop through, copy over the vertex data, keeping track of the new vertex IDs.
                     ttPart.Vertices = new List<TTVertex>(uniqueVertexIds.Count);
+
                     for (var i = 0; i < uniqueVertexIds.Count; i++)
                     {
                         var oldVertexId = uniqueVertexIds[i];
@@ -556,14 +552,14 @@ namespace xivModdingFramework.Models.Helpers
                         }
 
                         ttPart.Vertices.Add(ttVert);
-                        vertDict.Add(oldVertexId, ttPart.Vertices.Count - 1);
+                        vertMap[oldVertexId] = ttPart.Vertices.Count - 1;
                     }
 
                     // Now we need to copy in the triangle indices, pointing to the new, part-level vertex IDs.
-                    ttPart.TriangleIndices = new List<int>(indices.Count);
+                    ttPart.TriangleIndices = new List<int>(indexCount);
                     foreach (var oldVertexId in indices)
                     {
-                        ttPart.TriangleIndices.Add(vertDict[oldVertexId]);
+                        ttPart.TriangleIndices.Add(vertMap[oldVertexId]);
                     }
 
                     // Ok, gucci now.


### PR DESCRIPTION
The overall result of this is to reduce the time spent in Mdl.GetXivMdl() + TTModel.FromRaw() for an 85k vert model from ~700ms to ~100ms.

* Changing SortedSet to HashSet + Max() + Sort() in MergeGeometryData() gives about a 20x speed up of this function.
* Changing ReadVertexData() to take a byte[] instead of a BinaryReader, for some reason, gives about a 2-3x speed up of this function.

I think the byte array must be explained by it allowing the compiler to optimize some code better. The idea was that it would allow the code to be re-written by inverting the loops and using BitConverter, and maybe even Parallel -- but with just this change it became fast enough anyway.