### PR TITLE
Put out more neck related fires

### DIFF
--- a/xivModdingFramework/Models/FileTypes/Mdl.cs
+++ b/xivModdingFramework/Models/FileTypes/Mdl.cs
@@ -1004,9 +1004,10 @@ namespace xivModdingFramework.Models.FileTypes
                     }
                 }
                 else { 
-                    if (xivMdl.LoDList[0].VertexDataOffset < br.BaseStream.Position
-                        || (xivMdl.LoDList[0].VertexDataOffset % 8 != br.BaseStream.Position % 8)
-                        && xivMdl.LoDList[1].VertexDataSize == 0)
+                    if ((xivMdl.LoDList[0].VertexDataOffset < br.BaseStream.Position
+                        || (xivMdl.LoDList[0].VertexDataOffset % 8 != br.BaseStream.Position % 8))
+                        && xivMdl.LoDList[1].VertexDataSize == 0 // Avoid applying this fix to vanilla models
+                        && xivMdl.ModelData.NeckMorphTableSize != 0x0A) // Avoid applying to face models, which were written incorrectly after patch 7.1
                     {
 
                         var delta = (int)(xivMdl.LoDList[0].VertexDataOffset - br.BaseStream.Position);
@@ -3607,6 +3608,10 @@ namespace xivModdingFramework.Models.FileTypes
 
                         bones.Add((byte)boneset0Index);
                     }
+
+                    // Fully abort building neck data if we gave up inside the previous loop
+                    if (basicModelBlock[neckMorphTableSizePointer] == 0)
+                        break;
 
                     // Serialize
                     neckMorphDataBlock.AddRange(BitConverter.GetBytes(positionAdjust.X));

--- a/xivModdingFramework/Mods/FileTypes/PMP.cs
+++ b/xivModdingFramework/Mods/FileTypes/PMP.cs
@@ -401,15 +401,14 @@ namespace xivModdingFramework.Mods.FileTypes.PMP
                             var value = 1UL << i;
                             if ((selected & value) > 0)
                             {
-                                var disableOpt = group.Options[i] as PmpDisableImcOptionJson;
-                                if (disableOpt != null)
+                                var opt = group.Options[i] as PmpImcOptionJson;
+                                if (opt.IsDisableSubMod)
                                 {
                                     // No options allowed >:|
                                     disabled = true;
                                     break;
                                 }
 
-                                var opt = group.Options[i] as PmpImcOptionJson;
                                 optionIdx++;
 
                                 xivImc.AttributeMask |= opt.AttributeMask;
@@ -1479,16 +1478,13 @@ namespace xivModdingFramework.Mods.FileTypes.PMP
         public int Priority = 0;
     }
 
-    public class PmpDisableImcOptionJson : PMPOptionJson
-    {
-        public bool IsDisableSubMod = true;
-    }
-
-    [JsonConverter(typeof(JsonSubtypes))]
-    [JsonSubtypes.KnownSubTypeWithProperty(typeof(PmpDisableImcOptionJson), "IsDisableSubMod")]
     public class PmpImcOptionJson : PMPOptionJson
     {
-        public ushort AttributeMask;
+        public bool IsDisableSubMod = false;
+        public ushort AttributeMask = 0;
+
+        public bool ShouldSerializeIsDisableSubMod() { return IsDisableSubMod; }
+        public bool ShouldSerializeAttributeMask() { return !IsDisableSubMod; }
     }
 
     #endregion

--- a/xivModdingFramework/Mods/WizardData.cs
+++ b/xivModdingFramework/Mods/WizardData.cs
@@ -514,17 +514,12 @@ namespace xivModdingFramework.Mods
             PMPOptionJson op;
             if (GroupType == EGroupType.Imc)
             {
-                if (ImcData.IsDisableOption)
-                {
-                    var io = new PmpDisableImcOptionJson();
-                    op = io;
-                }
-                else
-                {
-                    var io = new PmpImcOptionJson();
-                    op = io;
+                var io = new PmpImcOptionJson();
+                op = io;
+                if (!ImcData.IsDisableOption)
                     io.AttributeMask = ImcData.AttributeMask;
-                }
+                else
+                    io.IsDisableSubMod = true;
             }
             else
             {
@@ -831,17 +826,10 @@ namespace xivModdingFramework.Mods
                 {
                     var imcData = new WizardImcOptionData();
                     var imcOp = o as PmpImcOptionJson;
-                    if (imcOp != null)
-                    {
-                        imcData.IsDisableOption = false;
+                    if (!imcOp.IsDisableSubMod)
                         imcData.AttributeMask = imcOp.AttributeMask;
-                    }
-                    var defOp = o as PmpDisableImcOptionJson;
-                    if (defOp != null)
-                    {
-                        imcData.IsDisableOption = defOp.IsDisableSubMod;
-                        imcData.AttributeMask = 0;
-                    }
+                    else
+                        imcData.IsDisableOption = imcOp.IsDisableSubMod;
                     wizOp.ImcData = imcData;
                 }
 


### PR DESCRIPTION
Prevent triggering That One Piece Of Fix-up code for new faces -- since textools was writing garbage in the header but *without* the offset being incorrect.

This has the side-effect of meaning the code will never trigger again for a face mod made past this point in time, but that should be OK because the fix-up is an abomination and doesn't even match the game behavior.

I tried more a specific work-around but it seems like there's really just random garbage that got spliced in to the header for some reason. It means the bounding box data fails to read correctly for these models too? But that has no effect on anything in TexTools, at least.

---

Second edit is a mistake I made where not breaking out of a loop properly causes heads without the required bones in part 0.0 to fail in a way that **triggers the same fix-up code yet again** -- notably this apparently includes pre-dawntrail face models UGHHH. 
