### PR TITLE
Avoid import failure due to filenames with invalid 3 letter slot codes

### DIFF
--- a/xivModdingFramework/Cache/XivDependencyGraph.cs
+++ b/xivModdingFramework/Cache/XivDependencyGraph.cs
@@ -680,7 +680,12 @@ namespace xivModdingFramework.Cache
                 match = _slotRegex.Match(internalFilePath);
                 if (match.Success)
                 {
-                    info.Slot = match.Groups[1].Value;
+                    // Validate the slot name to avoid matching on arbitrary three letter strings that may be present
+                    if (XivItemTypes.GetAvailableSlots(info.PrimaryType).Contains(match.Groups[1].Value)
+                        || (info.SecondaryType.HasValue && XivItemTypes.GetAvailableSlots(info.SecondaryType.Value).Contains(match.Groups[1].Value)))
+                    {
+                        info.Slot = match.Groups[1].Value;
+                    }
                 }
             }
             else

--- a/xivModdingFramework/Materials/DataContainers/XivMtrl.cs
+++ b/xivModdingFramework/Materials/DataContainers/XivMtrl.cs
@@ -508,7 +508,7 @@ namespace xivModdingFramework.Materials.DataContainers
         public string GetItemTypeIdentifier()
         {
             // This regex feels a little janky, but it's good enough for now.
-            var match = Regex.Match(MTRLPath, "_([a-z]{3})_[a-z0-9]\\.mtrl");
+            var match = Regex.Match(MTRLPath, "_([a-z]{3})_[a-z0-9]+\\.mtrl");
             if (match.Success)
             {
                 return "_" + match.Groups[1].Value;


### PR DESCRIPTION
Two fixes:

1) Avoids accepting random 3 letter strings as a slot name, which causes a failure in some other code later on
2) Fixes the "Make unique textures" button from dropping the slot name from the generated texture filenames, if the material name isn't a single letter (TexTools lets you enter longer strings).

Example of (1): `v01_c0201a0053_xxx_blahblah_id_985398932.tex` as a filename in a modpack causes an import failure when some UI code tries to look-up what item/slot the file belongs to, because `_xxx_` is parsed as the item's slot type (like rir, ril, met, dwn, etc...)

*( It seems as if TexTools relies on parsing the filename, without any other context, to determine which item a file belongs to when importing. )*

Example of (2): Create a new material in TexTools with a name that isn't a single letter (e.g. "xxx"), then click "Make Textures Unique". The new filenames are generated without the slot code indicator, potentially leading to triggering the failure in (1) if the material name happened to be 3 letters.

(e.g. Before: `v01_c0201a0053_rir_a.tex` -> `v01_c0201a0053_xxx_123456789.tex`
After: `v01_c0201a0053_rir_a.tex` ->  `v01_c0201a0053_rir_xxx_123456789.tex` )


new PR which doesn't break demihumans :tada: 