### PR TITLE
Changes to PMP safe filenames.

### DIFF
--- a/xivModdingFramework/Helpers/IOUtil.cs
+++ b/xivModdingFramework/Helpers/IOUtil.cs
@@ -40,11 +40,14 @@ using xivModdingFramework.Cache;
 using System.Management;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using System.Text;
 
 namespace xivModdingFramework.Helpers
 {
     public static class IOUtil
     {
+        private static readonly HashSet<char> _InvalidFileNameChars = new(Path.GetInvalidFileNameChars());
+
         /// <summary>
         /// Compresses raw byte data.
         /// </summary>
@@ -729,16 +732,32 @@ namespace xivModdingFramework.Helpers
 
         public static string MakePathSafe(string fileName, bool makeLowercase = true)
         {
-            foreach (var c in Path.GetInvalidFileNameChars())
-            {
-                fileName = fileName.Replace(c, '-');
-            }
-            if (makeLowercase)
-            {
-                fileName = fileName.ToLower();
-            }
-            return fileName.Trim();
+            return IOUtil.MakePathSafe(fileName, '-', makeLowercase);
         }
+
+        public static string MakePathSafe(string fileName, char rep, bool makeLowercase = true)
+        {
+            // This approach walks the string once, and hash lookups are O(1).
+            StringBuilder ret = new(fileName.Length);
+            foreach (var c in fileName)
+            {
+                if (_InvalidFileNameChars.Contains(c))
+                {
+                    ret.Append(rep);
+                }
+                else if (makeLowercase)
+                {
+                    ret.Append(Char.ToLower(c));
+                }
+                else
+                {
+                    ret.Append(c);
+                }
+            }
+
+            return ret.ToString().Trim();
+        }
+
         public static void CopyFolder(string sourcePath, string targetPath)
         {
             sourcePath = MakeLongPath(sourcePath);
@@ -962,6 +981,5 @@ namespace xivModdingFramework.Helpers
                 Trace.WriteLine(ex);
             }
         }
-
     }
 }

--- a/xivModdingFramework/Mods/FileTypes/PMP.cs
+++ b/xivModdingFramework/Mods/FileTypes/PMP.cs
@@ -43,6 +43,9 @@ namespace xivModdingFramework.Mods.FileTypes.PMP
     public static class PMP
     {
         public const int _WriteFileVersion = 3;
+
+        private const char _PMPSafeNameReplacement = '_';
+
         private static bool _ImportActive = false;
         private static string _Source = null;
 
@@ -815,7 +818,7 @@ namespace xivModdingFramework.Mods.FileTypes.PMP
 
             for(int i = 0; i < pmp.Groups.Count; i++)
             {
-                var gName = IOUtil.MakePathSafe(pmp.Groups[i].Name.ToLower());
+                var gName = PMP.MakePMPPathSafe(pmp.Groups[i].Name);
                 var groupPath = Path.Combine(workingDirectory, "group_" + (i+1).ToString("D3") + "_" + gName + ".json");
                 var groupString = JsonConvert.SerializeObject(pmp.Groups[i], Formatting.Indented);
                 File.WriteAllText(groupPath, groupString);
@@ -1261,9 +1264,18 @@ namespace xivModdingFramework.Mods.FileTypes.PMP
             return (seenMetadata.Values.ToList(), seenRgsps.Values.ToList(), otherManipulations);
         }
 
+        private static string MakePMPPathSafe(string fileName)
+        {
+            // This method enforces the naming scheme that penumbra expects for its json components.
+            if (fileName == ".")
+                return new(_PMPSafeNameReplacement, 1);
+
+            if (fileName == "..")
+                return new(_PMPSafeNameReplacement, 2);
+
+            return IOUtil.MakePathSafe(fileName.Normalize(NormalizationForm.FormKC), _PMPSafeNameReplacement, true);
+        }
     }
-
-
 
     #region Penumbra Simple JSON Classes
     public class PMPJson


### PR DESCRIPTION
- Replaced multiple string walks for every character in a filename with a single walk, a buffer, and a hash for fast character lookup.
- Utilized new paradigm for both the existing MakeSafePath in IOUtil and a new PMP specific version.
- Implemented new PMP specific path sanitization that matches what Penumbra expects in its filenames.

The reason for this change is that currently if a modpack is created in TexTools that has invalid filename characters in one or more group names, the file name generated does not match what Penumbra expects such a json file to be named, so it recreates the json files on import. While this works, it does leave a number of ".bak" files on the file system. This change helps to align TexTools PMP creation with that of Penumbra and should alleviate this minor issue.

The refactor of the existing IOUtil.MakePathSafe was simply to improve its efficiency and to have a single, core method for all such functionality.