### PR TITLE
Fix edited Patch 7.2 faces causing broken shadows

### DIFF
--- a/xivModdingFramework/Models/FileTypes/Mdl.cs
+++ b/xivModdingFramework/Models/FileTypes/Mdl.cs
@@ -3030,18 +3030,12 @@ namespace xivModdingFramework.Models.FileTypes
 
                 // Unknowns that are probably partly padding.
                 // So far since Dawntrail, copying these blindly has only caused problems
-                /*
                 basicModelBlock.AddRange(BitConverter.GetBytes(ogModelData.Unknown13));
+                basicModelBlock.AddRange(BitConverter.GetBytes(new byte[]{0, 0})); // Patch 7.2 face shadows
                 basicModelBlock.AddRange(BitConverter.GetBytes(ogModelData.Unknown14));
                 basicModelBlock.AddRange(BitConverter.GetBytes(ogModelData.Unknown15));
                 basicModelBlock.AddRange(BitConverter.GetBytes(ogModelData.Unknown16));
                 basicModelBlock.AddRange(BitConverter.GetBytes(ogModelData.Unknown17));
-                */
-                basicModelBlock.AddRange(BitConverter.GetBytes(new byte[]{0, 0}));
-                basicModelBlock.AddRange(BitConverter.GetBytes(new byte[]{0, 0})); // Patch 7.2 face shadows
-                basicModelBlock.AddRange(BitConverter.GetBytes(new byte[]{0, 0}));
-                basicModelBlock.AddRange(BitConverter.GetBytes(new byte[]{0, 0}));
-                basicModelBlock.AddRange(BitConverter.GetBytes(new byte[]{0, 0}));
 
 
 

--- a/xivModdingFramework/Models/FileTypes/Mdl.cs
+++ b/xivModdingFramework/Models/FileTypes/Mdl.cs
@@ -3029,11 +3029,19 @@ namespace xivModdingFramework.Models.FileTypes
                 basicModelBlock.AddRange(BitConverter.GetBytes((short)0));
 
                 // Unknowns that are probably partly padding.
+                // So far since Dawntrail, copying these blindly has only caused problems
+                /*
                 basicModelBlock.AddRange(BitConverter.GetBytes(ogModelData.Unknown13));
                 basicModelBlock.AddRange(BitConverter.GetBytes(ogModelData.Unknown14));
                 basicModelBlock.AddRange(BitConverter.GetBytes(ogModelData.Unknown15));
                 basicModelBlock.AddRange(BitConverter.GetBytes(ogModelData.Unknown16));
                 basicModelBlock.AddRange(BitConverter.GetBytes(ogModelData.Unknown17));
+                */
+                basicModelBlock.AddRange(BitConverter.GetBytes(new byte[]{0, 0}));
+                basicModelBlock.AddRange(BitConverter.GetBytes(new byte[]{0, 0})); // Patch 7.2 face shadows
+                basicModelBlock.AddRange(BitConverter.GetBytes(new byte[]{0, 0}));
+                basicModelBlock.AddRange(BitConverter.GetBytes(new byte[]{0, 0}));
+                basicModelBlock.AddRange(BitConverter.GetBytes(new byte[]{0, 0}));
 
 
 
@@ -3638,6 +3646,7 @@ namespace xivModdingFramework.Models.FileTypes
 
                 var paddingDataBlock = new List<byte>();
 
+                // Since patch 7.2, faces contain extra data inside of the "padding" here
                 paddingDataBlock.Add(ogMdl.PaddingSize);
                 paddingDataBlock.AddRange(ogMdl.PaddedBytes);
 


### PR DESCRIPTION
So far preserving unknown model data without adjusting the rest of the code has caused:

 - very broken neck seams in patch 7.1, and
 - very broken projected shadows in patch 7.2

Seems safer to just always write zeroes for these, since they seem very likely to come along with new data blocks that need to be supported for the values to make sense.