### PR TITLE
Patch 7.2 new face shadow data support

### DIFF
--- a/xivModdingFramework/Models/DataContainers/MdlModelData.cs
+++ b/xivModdingFramework/Models/DataContainers/MdlModelData.cs
@@ -187,7 +187,7 @@ namespace xivModdingFramework.Models.DataContainers
         /// <summary>
         /// Unknown Usage
         /// </summary>
-        public short Unknown14 { get; set; }
+        public short Patch72TableSize { get; set; }
 
         /// <summary>
         /// Padding?
@@ -245,7 +245,7 @@ namespace xivModdingFramework.Models.DataContainers
                 BoneSetSize = br.ReadInt16(),
 
                 Unknown13 = br.ReadInt16(),
-                Unknown14 = br.ReadInt16(),
+                Patch72TableSize = br.ReadInt16(),
                 Unknown15 = br.ReadInt16(),
                 Unknown16 = br.ReadInt16(),
                 Unknown17 = br.ReadInt16()
@@ -281,7 +281,7 @@ namespace xivModdingFramework.Models.DataContainers
             br.Write(NeckMorphTableSize);
             br.Write(BoneSetSize);
             br.Write(Unknown13);
-            br.Write(Unknown14);
+            br.Write(Patch72TableSize);
             br.Write(Unknown15);
             br.Write(Unknown16);
             br.Write(Unknown17);

--- a/xivModdingFramework/Models/DataContainers/UnknownDataPatch72.cs
+++ b/xivModdingFramework/Models/DataContainers/UnknownDataPatch72.cs
@@ -1,0 +1,29 @@
+﻿// xivModdingFramework
+// Copyright © 2018 Rafael Gonzalez - All Rights Reserved
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace xivModdingFramework.Models.DataContainers
+{
+    public class UnknownDataPatch72
+    {
+        /// <summary>
+        /// This data block is currently unknown
+        /// </summary>
+        /// <remarks>
+        /// The size of this unknown data block is [ MdlModelData.Patch72TableSize * 16 ]
+        /// </remarks>
+        public byte[] Unknown { get; set; }
+    }
+}

--- a/xivModdingFramework/Models/DataContainers/XivMdl.cs
+++ b/xivModdingFramework/Models/DataContainers/XivMdl.cs
@@ -146,5 +146,10 @@ namespace xivModdingFramework.Models.DataContainers
         /// This data is present on heads and seems to affect the shape of the neck on the body mesh
         /// </summary>
         public List<NeckMorphEntry> NeckMorphTable { get; set; }
+
+        /// <summary>
+        /// Currently unknown data
+        /// </summary>
+        public UnknownDataPatch72 UnkDataPatch72 { get; set; }
     }
 }

--- a/xivModdingFramework/Models/FileTypes/Mdl.cs
+++ b/xivModdingFramework/Models/FileTypes/Mdl.cs
@@ -943,6 +943,15 @@ namespace xivModdingFramework.Models.FileTypes
                 }
                 #endregion
 
+                #region Patch 7.2 Unknown Data
+                // Something to do with shadows (appears on face models new in Patch 7.2)
+                var unkDataPatch72 = new UnknownDataPatch72
+                {
+                    Unknown = br.ReadBytes(xivMdl.ModelData.Patch72TableSize * 16)
+                };
+                xivMdl.UnkDataPatch72 = unkDataPatch72;
+                #endregion
+
                 #region Padding
                 // Padding
                 xivMdl.PaddingSize = br.ReadByte();
@@ -3030,7 +3039,7 @@ namespace xivModdingFramework.Models.FileTypes
 
                 // Unknowns that are probably partly padding.
                 basicModelBlock.AddRange(BitConverter.GetBytes(ogModelData.Unknown13));
-                basicModelBlock.AddRange(BitConverter.GetBytes(ogModelData.Unknown14));
+                basicModelBlock.AddRange(BitConverter.GetBytes(ogModelData.Patch72TableSize));
                 basicModelBlock.AddRange(BitConverter.GetBytes(ogModelData.Unknown15));
                 basicModelBlock.AddRange(BitConverter.GetBytes(ogModelData.Unknown16));
                 basicModelBlock.AddRange(BitConverter.GetBytes(ogModelData.Unknown17));
@@ -3633,6 +3642,11 @@ namespace xivModdingFramework.Models.FileTypes
                 }
                 #endregion
 
+                // Patch 7.2 Unknown Data
+                #region Patch 7.2 Unknown Data
+                var unknownPatch72DataBlock = ogMdl.UnkDataPatch72.Unknown;
+                #endregion
+
                 // Padding 
                 #region Padding Data Block
 
@@ -3788,7 +3802,7 @@ namespace xivModdingFramework.Models.FileTypes
                 // This is the offset to the beginning of the vertex data
                 var combinedDataBlockSize = _MdlHeaderSize + vertexInfoBlock.Count + pathInfoBlock.Count + basicModelBlock.Count + unknownDataBlock0.Length + (60 * ogMdl.LoDList.Count) + extraMeshesBlock.Count + meshDataBlock.Count +
                     attributePathDataBlock.Count + (unknownDataBlock1?.Length ?? 0) + meshPartDataBlock.Count + unknownDataBlock2.Length + matPathOffsetDataBlock.Count + bonePathOffsetDataBlock.Count +
-                    boneSetsBlock.Count + FullShapeDataBlock.Count + partBoneSetsBlock.Count + neckMorphDataBlock.Count + paddingDataBlock.Count + boundingBoxDataBlock.Count + boneBoundingBoxDataBlock.Count;
+                    boneSetsBlock.Count + FullShapeDataBlock.Count + partBoneSetsBlock.Count + neckMorphDataBlock.Count + unknownPatch72DataBlock.Length + paddingDataBlock.Count + boundingBoxDataBlock.Count + boneBoundingBoxDataBlock.Count;
 
                 var lodDataBlock = new List<byte>();
                 List<int> indexStartInjectPointers = new List<int>();
@@ -3876,6 +3890,7 @@ namespace xivModdingFramework.Models.FileTypes
                 modelDataBlock.AddRange(FullShapeDataBlock);
                 modelDataBlock.AddRange(partBoneSetsBlock);
                 modelDataBlock.AddRange(neckMorphDataBlock);
+                modelDataBlock.AddRange(unknownPatch72DataBlock);
                 modelDataBlock.AddRange(paddingDataBlock);
                 modelDataBlock.AddRange(boundingBoxDataBlock);
                 modelDataBlock.AddRange(boneBoundingBoxDataBlock);


### PR DESCRIPTION
Support new data to stop Patch 7.2 face shadows exploding in to squares and random data being written in to the padding yippee

I decided to keep to the "copy from original model" concept since I tested a very custom head and it didn't seem to break the shadows or neck seam on it.