### PR TITLE
Don't preserve Patch 7.2 face data...

### DIFF
--- a/xivModdingFramework/Models/FileTypes/Mdl.cs
+++ b/xivModdingFramework/Models/FileTypes/Mdl.cs
@@ -3039,7 +3039,11 @@ namespace xivModdingFramework.Models.FileTypes
 
                 // Unknowns that are probably partly padding.
                 basicModelBlock.AddRange(BitConverter.GetBytes(ogModelData.Unknown13));
-                basicModelBlock.AddRange(BitConverter.GetBytes(ogModelData.Patch72TableSize));
+                // XXX: Not preserving new Patch 7.2 face data
+                // It seems to have a dependency on the number of vertices, and thus crashes with custom models with fewer of them
+                // It also has a dependency on the order of vertices, and thus has poor results when Blender decides to shuffle them around...
+                //basicModelBlock.AddRange(BitConverter.GetBytes(ogModelData.Patch72TableSize));
+                basicModelBlock.AddRange(new byte[] { 0, 0 });
                 basicModelBlock.AddRange(BitConverter.GetBytes(ogModelData.Unknown15));
                 basicModelBlock.AddRange(BitConverter.GetBytes(ogModelData.Unknown16));
                 basicModelBlock.AddRange(BitConverter.GetBytes(ogModelData.Unknown17));
@@ -3644,7 +3648,10 @@ namespace xivModdingFramework.Models.FileTypes
 
                 // Patch 7.2 Unknown Data
                 #region Patch 7.2 Unknown Data
-                var unknownPatch72DataBlock = ogMdl.UnkDataPatch72.Unknown;
+                // XXX: Not preserving Patch 7.2 face data
+                //var unknownPatch72DataBlock = ogMdl.UnkDataPatch72.Unknown;
+                var unknownPatch72DataBlock = Array.Empty<byte>();
+
                 #endregion
 
                 // Padding 


### PR DESCRIPTION
Ick sorry preserving this data causes multiple problems:

- Importing a mesh with fewer vertices than the vanilla head makes the game crash
- Importing a mesh with differently ordered vertices (or different geometry) gives an incorrect shadow result

Unfortunately stripping this data disables the game's usage of `shp_sdw_a` -- so its impossible for people to take advantage of the new lighting feature at all right now.

Its currently not clear what this data actually is -- beyond the fact that its a list of vec3 that seems to apply per-vertex to affect the lighting in some way.

Stripping this data unconditionally also means any edit at all made to a vanilla head will cause the new lighting changes to revert back -- i.e. become the "No Voldemort" example here:

![image](https://github.com/user-attachments/assets/150174e4-4da1-4170-a438-facc248a8e8c)
