### PR TITLE
Fix colorset row previews

### DIFF
--- a/xivModdingFramework/Models/ModelTextures/ModelTexture.cs
+++ b/xivModdingFramework/Models/ModelTextures/ModelTexture.cs
@@ -1439,7 +1439,7 @@ namespace xivModdingFramework.Models.ModelTextures
         public static (int RowId, float Blend) ReadColorIndex(float indexRed, float indexGreen)
         {
             int byteRed = (int) Math.Round(indexRed * 255.0f);
-            int rowNumber = (int) (byteRed / (_ColorsetMul));
+            int rowNumber = (int) Math.Round(byteRed / (_ColorsetMul));
 
             float blendAmount = 1.0f - indexGreen;
 


### PR DESCRIPTION
Currently, when interpreting texture values to colorset rows, the value is not rounded before type casting.
This drops the decimal, so a value of 236 will be interpreted as 221 (Row 14B), when it should be rounded to 238 (Row 15B):
![image](https://github.com/user-attachments/assets/b0294c77-d48c-4566-8798-aa0cd5ca16c3)
![image](https://github.com/user-attachments/assets/5beafd45-c97e-45cc-bfc7-23ac51f30ffb)

With fix:
![image](https://github.com/user-attachments/assets/462af79e-ac88-4250-b161-26c42308b8eb)
![image](https://github.com/user-attachments/assets/311284f3-221c-48bc-a8b6-165bd0558fae)
