### PR TITLE
Fix Tex File mipmap offsets

### DIFF
--- a/xivModdingFramework/Mods/FileTypes/PMP.cs
+++ b/xivModdingFramework/Mods/FileTypes/PMP.cs
@@ -593,7 +593,7 @@ namespace xivModdingFramework.Mods.FileTypes.PMP
                     {
                         try
                         {
-                            var resized = await EndwalkerUpgrade.ValidateTextureSizes(data);
+                            var resized = await EndwalkerUpgrade.ValidateTexFileData(data);
                             if(resized != null)
                             {
                                 data = resized;

--- a/xivModdingFramework/Mods/FileTypes/PMP.cs
+++ b/xivModdingFramework/Mods/FileTypes/PMP.cs
@@ -74,7 +74,22 @@ namespace xivModdingFramework.Mods.FileTypes.PMP
                     {
                         // Unzip everything.
                         await IOUtil.UnzipFiles(path, tempFolder);
-                    } else
+
+                        // Quick check of tex file headers after unpacking from PMP modpacks
+                        // It is safe to rewrite the files here, as they are unzipped to a temporary path
+                        foreach (var filePath in IOUtil.GetFilesInFolder(tempFolder))
+                        {
+                            if (filePath.EndsWith(".tex"))
+                            {
+                                try
+                                {
+                                    _ = EndwalkerUpgrade.FastValidateTexFile(filePath);
+                                }
+                                catch { }
+                            }
+                        }
+                    }
+                    else
                     {
                         // Just JSON files.
                         await IOUtil.UnzipFiles(path, tempFolder, (file) =>
@@ -1063,6 +1078,18 @@ namespace xivModdingFramework.Mods.FileTypes.PMP
                 }
 
                 var externalPath = Path.Combine(unzipPath, file.Value);
+
+                // Quick check of tex file headers after unpacking from PMP modpacks
+                // It is safe to rewrite the files here, as they are unzipped to a temporary path
+                if (!alreadyUnzipped && internalPath.EndsWith(".tex"))
+                {
+                    try
+                    {
+                        _ = EndwalkerUpgrade.FastValidateTexFile(externalPath);
+                    }
+                    catch { }
+                }
+
                 var fileInfo = new FileStorageInformation()
                 {
                     StorageType = EFileStorageType.UncompressedIndividual,

--- a/xivModdingFramework/Mods/FileTypes/TTMP.cs
+++ b/xivModdingFramework/Mods/FileTypes/TTMP.cs
@@ -104,7 +104,7 @@ namespace xivModdingFramework.Mods.FileTypes
             ".cmp", ".imc", ".eqdp", ".eqp", ".gmp", ".est"
         };
 
-        internal const string _currentTTMPVersion = "2.0";
+        internal const string _currentTTMPVersion = "2.1";
 
         internal const char _typeCodeSimple = 's';
         internal const char _typeCodeWizard = 'w';
@@ -908,9 +908,12 @@ namespace xivModdingFramework.Mods.FileTypes
         {
             if (string.IsNullOrEmpty(version))
                 return true;
-
-            Int32.TryParse(version.Substring(0, 1), out var v);
-            return v < 2;
+            int major = 0, minor = 0;
+            string[] parts = version.Split('.');
+            int.TryParse(parts[0], out major);
+            if (parts.Length > 1)
+                int.TryParse(new(parts[1].TakeWhile(char.IsDigit).ToArray()), out minor);
+            return major < 2 || (major == 2 && minor == 0);
         }
 
 

--- a/xivModdingFramework/Mods/FileTypes/TTMP.cs
+++ b/xivModdingFramework/Mods/FileTypes/TTMP.cs
@@ -1408,7 +1408,7 @@ namespace xivModdingFramework.Mods.FileTypes
 
             var data = await TransactionDataHandler.GetUncompressedFile(info);
 
-            var resized = await EndwalkerUpgrade.ValidateTextureSizes(data);
+            var resized = await EndwalkerUpgrade.ValidateTexFileData(data);
             if(resized != null)
             {
                 data = resized;

--- a/xivModdingFramework/Mods/FileTypes/TTMP.cs
+++ b/xivModdingFramework/Mods/FileTypes/TTMP.cs
@@ -96,6 +96,13 @@ namespace xivModdingFramework.Mods.FileTypes
             Pmp
         };
 
+        public enum UpgradesNeeded
+        {
+            None = 0x00,
+            NeedsTexFix = 0x01,
+            NeedsMdlFix = 0x02
+        };
+
         // These file types are forbidden from being included in Modpacks or being imported via modpacks.
         // This is because these file types are re-built from constituent smaller files, and thus importing
         // a complete file would bash the user's current file state in unpredictable ways.
@@ -683,7 +690,9 @@ namespace xivModdingFramework.Mods.FileTypes
                     Dictionary<XivDataFile, List<string>> FilesPerDf = new Dictionary<XivDataFile, List<string>>();
 
 
-                    var needsTexFix = DoesModpackNeedTexFix(modpackMpl);
+                    var upgradesNeeded = DoesModpackNeedFix(modpackMpl);
+                    bool needsTexFix = (upgradesNeeded & UpgradesNeeded.NeedsTexFix) == UpgradesNeeded.NeedsTexFix;
+                    bool needsMdlFix = (upgradesNeeded & UpgradesNeeded.NeedsMdlFix) == UpgradesNeeded.NeedsMdlFix;
                     var count = 0;
                     var modList = await tx.GetModList();
 
@@ -729,7 +738,7 @@ namespace xivModdingFramework.Mods.FileTypes
                                 Trace.WriteLine(ex);
                                 continue;
                             }
-                        } else if(needsTexFix && modJson.FullPath.EndsWith(".mdl"))
+                        } else if(needsMdlFix && modJson.FullPath.EndsWith(".mdl"))
                         {
                             try
                             {
@@ -894,26 +903,30 @@ namespace xivModdingFramework.Mods.FileTypes
         /// </summary>
         /// <param name="modpackPath">The path to the modpack.</param>
         /// <returns>True if we must modify tex header uncompressed sizes, false otherwise.</returns>
-        public static bool DoesModpackNeedTexFix(DirectoryInfo modpackPath) {
+        public static UpgradesNeeded DoesModpackNeedFix(DirectoryInfo modpackPath) {
 
 	        var ver = GetVersion(modpackPath);
 
-            return DoesModpackNeedTexFix(ver);
+            return DoesModpackNeedFix(ver);
         }
-        public static bool DoesModpackNeedTexFix(ModPackJson mpl)
+        public static UpgradesNeeded DoesModpackNeedFix(ModPackJson mpl)
         {
-            return DoesModpackNeedTexFix(mpl.TTMPVersion);
+            return DoesModpackNeedFix(mpl.TTMPVersion);
         }
-        public static bool DoesModpackNeedTexFix(string version)
+        public static UpgradesNeeded DoesModpackNeedFix(string version)
         {
             if (string.IsNullOrEmpty(version))
-                return true;
+                version = "0.0";
             int major = 0, minor = 0;
             string[] parts = version.Split('.');
             int.TryParse(parts[0], out major);
             if (parts.Length > 1)
                 int.TryParse(new(parts[1].TakeWhile(char.IsDigit).ToArray()), out minor);
-            return major < 2 || (major == 2 && minor == 0);
+            if (major < 2)
+                return UpgradesNeeded.NeedsTexFix | UpgradesNeeded.NeedsMdlFix;
+            if (major == 2 && minor == 0)
+                return UpgradesNeeded.NeedsTexFix;
+            return UpgradesNeeded.None;
         }
 
 
@@ -1258,9 +1271,9 @@ namespace xivModdingFramework.Mods.FileTypes
                     mpl = await GetModpackList(modpackPath);
                 }
 
-                var needsTexFix = DoesModpackNeedTexFix(mpl);
+                UpgradesNeeded upgradesNeeded = DoesModpackNeedFix(mpl);
 
-                return await MakeFileStorageInformationDictionary(_tempMPD, mpl.SimpleModsList, needsTexFix, includeData);
+                return await MakeFileStorageInformationDictionary(_tempMPD, mpl.SimpleModsList, upgradesNeeded, includeData);
             });
         }
         private static async Task<Dictionary<string, FileStorageInformation>> UnpackWizardModlist(string modpackPath, bool includeData = true, ModTransaction tx = null)
@@ -1314,19 +1327,20 @@ namespace xivModdingFramework.Mods.FileTypes
 
                 var option = mpl.ModPackPages[0].ModGroups[0].OptionList[0];
 
-                var needsTexFix = DoesModpackNeedTexFix(mpl);
-                return await MakeFileStorageInformationDictionary(_tempMPD, option.ModsJsons, needsTexFix, includeData);
+                var upgradesNeeded = DoesModpackNeedFix(mpl);
+                return await MakeFileStorageInformationDictionary(_tempMPD, option.ModsJsons, upgradesNeeded, includeData);
 
             });
         }
 
-        private static async Task<Dictionary<string, FileStorageInformation>> MakeFileStorageInformationDictionary(string mpdPath, List<ModsJson> mods, bool needsTexFix, bool includeData = true)
+        private static async Task<Dictionary<string, FileStorageInformation>> MakeFileStorageInformationDictionary(string mpdPath, List<ModsJson> mods, UpgradesNeeded upgradesNeeded, bool includeData = true)
         {
             var ret = new Dictionary<string, FileStorageInformation>();
+            bool needsTexFix = (upgradesNeeded & UpgradesNeeded.NeedsTexFix) == UpgradesNeeded.NeedsTexFix;
+            bool needsMdlFix = (upgradesNeeded & UpgradesNeeded.NeedsMdlFix) == UpgradesNeeded.NeedsMdlFix;
+
             foreach (var file in mods)
             {
-
-
                 if (!includeData)
                 {
                     if (ret.ContainsKey(file.FullPath))
@@ -1363,7 +1377,7 @@ namespace xivModdingFramework.Mods.FileTypes
                         // Skip the file?
                         continue;
                     }
-                } else if(needsTexFix && file.FullPath.EndsWith(".mdl") && includeData)
+                } else if(needsMdlFix && file.FullPath.EndsWith(".mdl") && includeData)
                 {
                     try
                     {

--- a/xivModdingFramework/Textures/DataContainers/XivTex.cs
+++ b/xivModdingFramework/Textures/DataContainers/XivTex.cs
@@ -117,7 +117,6 @@ namespace xivModdingFramework.Textures.DataContainers
             }
 
             var header = TexHeader.ReadTexHeader(br);
-            TexHeader.FixUpBrokenMipOffsets(header, dataSize);
 
             var tex = new XivTex();
 

--- a/xivModdingFramework/Textures/DataContainers/XivTex.cs
+++ b/xivModdingFramework/Textures/DataContainers/XivTex.cs
@@ -117,6 +117,7 @@ namespace xivModdingFramework.Textures.DataContainers
             }
 
             var header = TexHeader.ReadTexHeader(br);
+            TexHeader.FixUpBrokenMipOffsets(header, dataSize);
 
             var tex = new XivTex();
 

--- a/xivModdingFramework/Textures/Enums/XivTexFormat.cs
+++ b/xivModdingFramework/Textures/Enums/XivTexFormat.cs
@@ -74,6 +74,58 @@ namespace xivModdingFramework.Textures.Enums
             var attribute = (XivTexFormatDescriptionAttribute[])field.GetCustomAttributes(typeof(XivTexFormatDescriptionAttribute), false);
             return attribute.Length > 0 ? attribute[0].DisplayName : value.ToString();
         }
+
+        public static bool IsCompressedFormat(this XivTexFormat value)
+        {
+            switch (value)
+            {
+                case XivTexFormat.DXT1:
+                case XivTexFormat.DXT3:
+                case XivTexFormat.DXT5:
+                case XivTexFormat.BC4:
+                case XivTexFormat.BC5:
+                case XivTexFormat.BC7:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        public static int GetMipMinDimension(this XivTexFormat value)
+        {
+            return value.IsCompressedFormat() ? 4 : 1;
+        }
+
+        public static int GetBitsPerPixel(this XivTexFormat value)
+        {
+            switch (value)
+            {
+                case XivTexFormat.DXT1:
+                case XivTexFormat.BC4:
+                    return 4;
+                case XivTexFormat.DXT5:
+                case XivTexFormat.BC5:
+                case XivTexFormat.A8:
+                case XivTexFormat.BC7:
+                    return 8;
+                case XivTexFormat.A1R5G5B5:
+                case XivTexFormat.A4R4G4B4:
+                    return 16;
+                case XivTexFormat.L8:
+                case XivTexFormat.A8R8G8B8:
+                case XivTexFormat.X8R8G8B8:
+                case XivTexFormat.R32F:
+                case XivTexFormat.G16R16F:
+                case XivTexFormat.G32R32F:
+                case XivTexFormat.A16B16G16R16F:
+                case XivTexFormat.A32B32G32R32F:
+                case XivTexFormat.DXT3:
+                case XivTexFormat.D16:
+                    return 32;
+            }
+
+            throw new ArgumentException("No BitsPerPixel defined for texture format");
+        }
     }
 
     [AttributeUsage(AttributeTargets.All)]

--- a/xivModdingFramework/Textures/FileTypes/DDS.cs
+++ b/xivModdingFramework/Textures/FileTypes/DDS.cs
@@ -58,11 +58,15 @@ namespace xivModdingFramework.Textures.FileTypes
             { (uint)BitConverter.ToInt32(Encoding.ASCII.GetBytes("BC4U"), 0) , XivTexFormat.BC4 },
             { (uint)BitConverter.ToInt32(Encoding.ASCII.GetBytes("ATI2"), 0) , XivTexFormat.BC5 },
             { (uint)BitConverter.ToInt32(Encoding.ASCII.GetBytes("BC5U"), 0) , XivTexFormat.BC5 },
-            { (uint)BitConverter.ToInt32(Encoding.ASCII.GetBytes("AR12"), 0) , XivTexFormat.A4R4G4B4 },
-            { (uint)BitConverter.ToInt32(Encoding.ASCII.GetBytes("AR15"), 0) , XivTexFormat.A1R5G5B5 },
+            { (uint)BitConverter.ToInt32(Encoding.ASCII.GetBytes("BC7L"), 0) , XivTexFormat.BC7 },
+            { (uint)BitConverter.ToInt32(Encoding.ASCII.GetBytes("BC7\0"), 0) , XivTexFormat.BC7 },
 
-            //ARGB 16F
-            { 0x71, XivTexFormat.A16B16G16R16F },
+            // Floating point formats
+            { 112, XivTexFormat.G16R16F },
+            { 113, XivTexFormat.A16B16G16R16F },
+            { 114, XivTexFormat.R32F },
+            { 115, XivTexFormat.G32R32F },
+            { 116, XivTexFormat.A32B32G32R32F },
 
             //Uncompressed RGBA
             { 0, XivTexFormat.A8R8G8B8 }
@@ -158,7 +162,6 @@ namespace xivModdingFramework.Textures.FileTypes
 
         private static byte[] CreateDDSHeader(XivTexFormat format, int width, int height, int layers, int mipCount)
         {
-            uint dwPitchOrLinearSize, pfFlags;
             var header = new List<byte>();
 
             if(layers <= 0)
@@ -175,50 +178,73 @@ namespace xivModdingFramework.Textures.FileTypes
             header.AddRange(BitConverter.GetBytes(dwSize));
 
             // Flags to indicate which members contain valid data.
-            uint dwFlags = 528391;
-            if(layers > 1)
-            {
-                dwFlags = 0x00000004;
-            }
-            header.AddRange(BitConverter.GetBytes(dwFlags));
+            uint dwFlags = 0x21007; // DDSD_MIPMAPCOUNT | DDSD_PIXELFORMAT | DDSD_WIDTH | DDSD_HEIGHT | DDSD_CAPS
 
             // Surface height (in pixels). 
             var dwHeight = (uint)height;
-            header.AddRange(BitConverter.GetBytes(dwHeight));
 
             // Surface width (in pixels).
             var dwWidth = (uint)width;
-            header.AddRange(BitConverter.GetBytes(dwWidth));
 
             // The pitch or number of bytes per scan line in an uncompressed texture; the total number of bytes in the top level texture for a compressed texture.
-            if (format == XivTexFormat.A16B16G16R16F)
-            {
-                dwPitchOrLinearSize = 512;
-            }
-            else if (format == XivTexFormat.A8R8G8B8)
-            {
-                dwPitchOrLinearSize = (dwHeight * dwWidth) * 4;
-            }
-            else if (format == XivTexFormat.DXT1)
-            {
-                dwPitchOrLinearSize = (dwHeight * dwWidth) / 2;
-            }
-            else if (format == XivTexFormat.A4R4G4B4 || format == XivTexFormat.A1R5G5B5)
-            {
-                dwPitchOrLinearSize = (dwHeight * dwWidth) * 2;
-            }
-            else
-            {
-                dwPitchOrLinearSize = dwHeight * dwWidth;
-            }
-            header.AddRange(BitConverter.GetBytes(dwPitchOrLinearSize));
+            uint dwPitchOrLinearSize;
 
+            switch (format)
+            {
+                case XivTexFormat.DXT1:
+                case XivTexFormat.BC4:
+                    dwPitchOrLinearSize = dwHeight * dwWidth / 2;
+                    dwFlags |= 0x80000; // DDSD_LINEARSIZE
+                    break;
+                case XivTexFormat.DXT3:
+                case XivTexFormat.DXT5:
+                case XivTexFormat.BC5:
+                case XivTexFormat.BC7:
+                    dwPitchOrLinearSize = dwHeight * dwWidth;
+                    dwFlags |= 0x80000; // DDSD_LINEARSIZE
+                    break;
+                case XivTexFormat.L8:
+                case XivTexFormat.A8:
+                    dwPitchOrLinearSize = dwWidth;
+                    dwFlags |= 0x8; // DDSD_PITCH
+                    break;
+                case XivTexFormat.A4R4G4B4:
+                case XivTexFormat.A1R5G5B5:
+                case XivTexFormat.D16:
+                    dwPitchOrLinearSize = dwWidth * 2;
+                    dwFlags |= 0x8; // DDSD_PITCH
+                    break;
+                case XivTexFormat.A8R8G8B8:
+                case XivTexFormat.X8R8G8B8:
+                case XivTexFormat.R32F:
+                case XivTexFormat.G16R16F:
+                    dwPitchOrLinearSize = dwWidth * 4;
+                    dwFlags |= 0x8; // DDSD_PITCH
+                    break;
+                case XivTexFormat.G32R32F:
+                case XivTexFormat.A16B16G16R16F:
+                    dwPitchOrLinearSize = dwWidth * 8;
+                    dwFlags |= 0x8; // DDSD_PITCH
+                    break;
+                case XivTexFormat.A32B32G32R32F:
+                    dwPitchOrLinearSize = dwWidth * 16;
+                    dwFlags |= 0x8; // DDSD_PITCH
+                    break;
+                case XivTexFormat.INVALID:
+                default:
+                    throw new InvalidDataException("DDS Writer does not know how to write TexFormat: " + format.ToString());
+            }
+
+            header.AddRange(BitConverter.GetBytes(dwFlags));
+            header.AddRange(BitConverter.GetBytes(dwHeight));
+            header.AddRange(BitConverter.GetBytes(dwWidth));
+            header.AddRange(BitConverter.GetBytes(dwPitchOrLinearSize));
 
             // Depth of a volume texture (in pixels), otherwise unused.
             const uint dwDepth = 0;
             header.AddRange(BitConverter.GetBytes(dwDepth));
 
-            // Number of mipmap levels, otherwise unused.
+            // Number of mipmap levels.
             var dwMipMapCount = (uint)mipCount;
             header.AddRange(BitConverter.GetBytes(dwMipMapCount));
 
@@ -233,213 +259,109 @@ namespace xivModdingFramework.Textures.FileTypes
             const uint pfSize = 32;
             header.AddRange(BitConverter.GetBytes(pfSize));
 
-            switch (format)
-            {
-                // Values which indicate what type of data is in the surface.
-                case XivTexFormat.A8R8G8B8:
-                case XivTexFormat.A4R4G4B4:
-                case XivTexFormat.A1R5G5B5:
-                    pfFlags = 65;
-                    break;
-                case XivTexFormat.A8:
-                    pfFlags = 2;
-                    break;
-                default:
-                    pfFlags = 4;
-                    break;
-            }
-            header.AddRange(BitConverter.GetBytes(pfFlags));
-
+            // Compressed and floating point formats will be identified by a FourCC code
             uint dwFourCC = GetDDSType(format);
-            if (layers > 1 || (dwFourCC == 0 && format != XivTexFormat.A8R8G8B8))
-            {
+
+            uint pfFlags = 0;
+            uint dwRGBBitCount = 0;
+            uint dwRBitMask = 0;
+            uint dwGBitMask = 0;
+            uint dwBBitMask = 0;
+            uint dwABitMask = 0;
+            uint dwCaps = 0x1000; // DDSCAPS_TEXTURE
+
+            // Multi-layer images must use the DX10 extension
+            if (layers > 1)
                 dwFourCC = _DX10;
-            }
 
-            header.AddRange(BitConverter.GetBytes(dwFourCC));
+            // Use DX10 header for BC7 for better compatibility
+            if (format == XivTexFormat.BC7)
+                dwFourCC = _DX10;
 
+            // Define the pixel layout for uncompressed integer formats
             switch (format)
             {
                 case XivTexFormat.A8R8G8B8:
-                    {
-                        // Number of bits in an RGB (possibly including alpha) format.
-                        const uint dwRGBBitCount = 32;
-                        header.AddRange(BitConverter.GetBytes(dwRGBBitCount));
-
-                        // Red (or lumiannce or Y) mask for reading color data. 
-                        const uint dwRBitMask = 16711680;
-                        header.AddRange(BitConverter.GetBytes(dwRBitMask));
-
-                        // Green (or U) mask for reading color data.
-                        const uint dwGBitMask = 65280;
-                        header.AddRange(BitConverter.GetBytes(dwGBitMask));
-
-                        // Blue (or V) mask for reading color data.
-                        const uint dwBBitMask = 255;
-                        header.AddRange(BitConverter.GetBytes(dwBBitMask));
-
-                        // Alpha mask for reading alpha data.
-                        const uint dwABitMask = 4278190080;
-                        header.AddRange(BitConverter.GetBytes(dwABitMask));
-
-                        // DDS_PIXELFORMAT End
-
-                        // Specifies the complexity of the surfaces stored.
-                        const uint dwCaps = 4096;
-                        header.AddRange(BitConverter.GetBytes(dwCaps));
-
-                        // dwCaps2, dwCaps3, dwCaps4, dwReserved2.
-                        // Unused.
-                        var blank1 = new byte[16];
-                        header.AddRange(blank1);
-
-                        break;
-                    }
-                case XivTexFormat.A8:
-                    {
-                        // Number of bits in an RGB (possibly including alpha) format.
-                        const uint dwRGBBitCount = 8;
-                        header.AddRange(BitConverter.GetBytes(dwRGBBitCount));
-
-                        // Red (or lumiannce or Y) mask for reading color data. 
-                        const uint dwRBitMask = 0;
-                        header.AddRange(BitConverter.GetBytes(dwRBitMask));
-
-                        // Green (or U) mask for reading color data.
-                        const uint dwGBitMask = 0;
-                        header.AddRange(BitConverter.GetBytes(dwGBitMask));
-
-                        // Blue (or V) mask for reading color data.
-                        const uint dwBBitMask = 0;
-                        header.AddRange(BitConverter.GetBytes(dwBBitMask));
-
-                        // Alpha mask for reading alpha data.
-                        const uint dwABitMask = 255;
-                        header.AddRange(BitConverter.GetBytes(dwABitMask));
-
-                        // DDS_PIXELFORMAT End
-
-                        // Specifies the complexity of the surfaces stored.
-                        const uint dwCaps = 4096;
-                        header.AddRange(BitConverter.GetBytes(dwCaps));
-
-                        // dwCaps2, dwCaps3, dwCaps4, dwReserved2.
-                        // Unused.
-                        var blank1 = new byte[16];
-                        header.AddRange(blank1);
-                        break;
-                    }
-                case XivTexFormat.A1R5G5B5:
-                    {
-                        // Number of bits in an RGB (possibly including alpha) format.
-                        const uint dwRGBBitCount = 16;
-                        header.AddRange(BitConverter.GetBytes(dwRGBBitCount));
-
-                        // Red (or lumiannce or Y) mask for reading color data. 
-                        const uint dwRBitMask = 31744;
-                        header.AddRange(BitConverter.GetBytes(dwRBitMask));
-
-                        // Green (or U) mask for reading color data.
-                        const uint dwGBitMask = 992;
-                        header.AddRange(BitConverter.GetBytes(dwGBitMask));
-
-                        // Blue (or V) mask for reading color data.
-                        const uint dwBBitMask = 31;
-                        header.AddRange(BitConverter.GetBytes(dwBBitMask));
-
-                        // Alpha mask for reading alpha data.
-                        const uint dwABitMask = 32768;
-                        header.AddRange(BitConverter.GetBytes(dwABitMask));
-
-                        // DDS_PIXELFORMAT End
-
-                        // Specifies the complexity of the surfaces stored.
-                        const uint dwCaps = 4096;
-                        header.AddRange(BitConverter.GetBytes(dwCaps));
-
-                        // dwCaps2, dwCaps3, dwCaps4, dwReserved2.
-                        // Unused.
-                        var blank1 = new byte[16];
-                        header.AddRange(blank1);
-                        break;
-                    }
+                    pfFlags |= 0x41; // DDPF_RGB | DDPF_ALPHAPIXELS
+                    dwRGBBitCount = 32;
+                    dwRBitMask = 0xFF0000;
+                    dwGBitMask = 0xFF00;
+                    dwBBitMask = 0xFF;
+                    dwABitMask = 0xFF000000;
+                    break;
+                case XivTexFormat.X8R8G8B8:
+                    pfFlags |= 0x40; // DDPF_RGB
+                    dwRGBBitCount = 32;
+                    dwRBitMask = 0xFF0000;
+                    dwGBitMask = 0xFF00;
+                    dwBBitMask = 0xFF;
+                    break;
                 case XivTexFormat.A4R4G4B4:
-                    {
-                        // Number of bits in an RGB (possibly including alpha) format.
-                        const uint dwRGBBitCount = 16;
-                        header.AddRange(BitConverter.GetBytes(dwRGBBitCount));
-
-                        // Red (or lumiannce or Y) mask for reading color data. 
-                        const uint dwRBitMask = 3840;
-                        header.AddRange(BitConverter.GetBytes(dwRBitMask));
-
-                        // Green (or U) mask for reading color data.
-                        const uint dwGBitMask = 240;
-                        header.AddRange(BitConverter.GetBytes(dwGBitMask));
-
-                        // Blue (or V) mask for reading color data.
-                        const uint dwBBitMask = 15;
-                        header.AddRange(BitConverter.GetBytes(dwBBitMask));
-
-                        // Alpha mask for reading alpha data.
-                        const uint dwABitMask = 61440;
-                        header.AddRange(BitConverter.GetBytes(dwABitMask));
-
-                        // DDS_PIXELFORMAT End
-
-                        // Specifies the complexity of the surfaces stored.
-                        const uint dwCaps = 4096;
-                        header.AddRange(BitConverter.GetBytes(dwCaps));
-
-                        // dwCaps2, dwCaps3, dwCaps4, dwReserved2.
-                        // Unused.
-                        var blank1 = new byte[16];
-                        header.AddRange(blank1);
-                        break;
-                    }
+                    pfFlags |= 0x41; // DDPF_RGB | DDPF_ALPHAPIXELS
+                    dwRGBBitCount = 16;
+                    dwRBitMask = 0b0000111100000000;
+                    dwGBitMask = 0b0000000011110000;
+                    dwBBitMask = 0b0000000000001111;
+                    dwABitMask = 0b1111000000000000;
+                    break;
+                case XivTexFormat.A1R5G5B5:
+                    pfFlags |= 0x41; // DDPF_RGB | DDPF_ALPHAPIXELS
+                    dwRGBBitCount = 16;
+                    dwRBitMask = 0b0111110000000000;
+                    dwGBitMask = 0b0000001111100000;
+                    dwBBitMask = 0b0000000000011111;
+                    dwABitMask = 0b1000000000000000;
+                    break;
+                case XivTexFormat.L8:
+                    pfFlags |= 0x200000; // DDPF_LUMINANCE
+                    dwRGBBitCount = 8;
+                    dwRBitMask = 0xFF;
+                    break;
+                case XivTexFormat.A8:
+                    pfFlags |= 0x02; // DDPF_ALPHA
+                    dwRGBBitCount = 8;
+                    dwABitMask = 0xFF;
+                    break;
                 default:
-                    {
-                        // dwRGBBitCount, dwRBitMask, dwGBitMask, dwBBitMask, dwABitMask, dwCaps, dwCaps2, dwCaps3, dwCaps4, dwReserved2.
-                        // Unused.
-                        var blank1 = new byte[40];
-                        header.AddRange(blank1);
-                        break;
-                    }
+                    if (dwFourCC == 0)
+                        throw new InvalidDataException("DDS Writer does not know how to write TexFormat: " + format.ToString());
+                    break;
             }
 
-            // Need to write DX10 header here.
-            if(dwFourCC == _DX10)
+            if (dwFourCC != 0)
+                pfFlags = 0x04; // DDPF_FOURCC
+
+            if (mipCount > 1)
+                dwCaps |= 0x400000; // DDSCAPS_MIPMAP
+
+            header.AddRange(BitConverter.GetBytes(pfFlags));
+            header.AddRange(BitConverter.GetBytes(dwFourCC));
+            header.AddRange(BitConverter.GetBytes(dwRGBBitCount));
+            header.AddRange(BitConverter.GetBytes(dwRBitMask));
+            header.AddRange(BitConverter.GetBytes(dwGBitMask));
+            header.AddRange(BitConverter.GetBytes(dwBBitMask));
+            header.AddRange(BitConverter.GetBytes(dwABitMask));
+            header.AddRange(BitConverter.GetBytes(dwCaps));
+
+            // DDS_PIXELFORMAT End
+
+            // dwCaps2, dwCaps3, dwCaps4, dwReserved2
+            header.AddRange(BitConverter.GetBytes(0));
+            header.AddRange(BitConverter.GetBytes(0));
+            header.AddRange(BitConverter.GetBytes(0));
+            header.AddRange(BitConverter.GetBytes(0));
+
+            // Need to write DX10 header for some compressed formats or multi-layer images
+            if (dwFourCC == _DX10)
             {
                 // DXGI_FORMAT dxgiFormat
-                uint dxgiFormat = 0;
-                if (format == XivTexFormat.DXT1) {
-                    dxgiFormat = (uint)DXGI_FORMAT.DXGI_FORMAT_BC1_UNORM;
-                } else if (format == XivTexFormat.DXT3)
-                {
-                    dxgiFormat = (uint)DXGI_FORMAT.DXGI_FORMAT_BC2_UNORM;
-                } else if (format == XivTexFormat.DXT5)
-                {
-                    dxgiFormat = (uint)DXGI_FORMAT.DXGI_FORMAT_BC3_UNORM;
-                } else if (format == XivTexFormat.BC4)
-                {
-                    dxgiFormat = (uint)DXGI_FORMAT.DXGI_FORMAT_BC4_UNORM;					
-                } else if (format == XivTexFormat.BC5)
-                {
-                    dxgiFormat = (uint)DXGI_FORMAT.DXGI_FORMAT_BC5_UNORM;
-                } else if (format == XivTexFormat.BC7)
-                {
-                    dxgiFormat = (uint)DXGI_FORMAT.DXGI_FORMAT_BC7_UNORM;
-                } else if (format == XivTexFormat.A8R8G8B8) {
-                    dxgiFormat = (uint)DXGI_FORMAT.DXGI_FORMAT_R8G8B8A8_UNORM;
-                } else
-                {
+                uint dxgiFormat = GetDxgiType(format);
+                if (dxgiFormat == 0)
                     throw new InvalidDataException("DDS Writer does not know how to write TexFormat: " + format.ToString());
-                }
                 header.AddRange(BitConverter.GetBytes(dxgiFormat));
 
                 // D3D10_RESOURCE_DIMENSION resourceDimension
-                header.AddRange(BitConverter.GetBytes((int)3));
-
+                header.AddRange(BitConverter.GetBytes((int)3)); // DDS_DIMENSION_TEXTURE2D
 
                 // UINT miscFlag
                 header.AddRange(BitConverter.GetBytes((int)0));

--- a/xivModdingFramework/Textures/FileTypes/Tex.cs
+++ b/xivModdingFramework/Textures/FileTypes/Tex.cs
@@ -162,9 +162,10 @@ namespace xivModdingFramework.Textures.FileTypes
                 return res;
             }
 
-            // Many tex files were written with broken mipmap offsets. Try to rebuild them here, using the total tex file size as a heuristic
-            // Returns true if any data was changed
-            internal static bool FixUpBrokenMipOffsets(TexHeader header, long texSizeIncludingHeader)
+            // Many tex files were written with broken mipmap offsets, and extra data at the end.
+            // Try to rebuild them here, using the total tex file size as a heuristic
+            // Returns a flag indicating if any data was changed, as well as the size in bytes that the tex file should be
+            internal static (bool HeaderChanged, long CalculatedTexSize) FixUpBrokenMipOffsets(TexHeader header, long texSizeIncludingHeader)
             {
                 bool modified = false;
                 int originalMipCount = header.MipCount;
@@ -230,7 +231,7 @@ namespace xivModdingFramework.Textures.FileTypes
 
                 modified |= (header.MipCount != originalMipCount);
 
-                return modified;
+                return (modified, mipOffset);
             }
         }
 
@@ -1309,7 +1310,7 @@ namespace xivModdingFramework.Textures.FileTypes
 
             // Fix broken tex file headers while we have a chance
             // This occurs before a tex file is written to game files or ttmp2 modpacks
-            TexHeader.FixUpBrokenMipOffsets(header, lengthIncludingHeader);
+            _ = TexHeader.FixUpBrokenMipOffsets(header, lengthIncludingHeader);
 
             List<byte> newTex = new List<byte>();
             // Here we need to read the texture header.

--- a/xivModdingFramework/Textures/FileTypes/Tex.cs
+++ b/xivModdingFramework/Textures/FileTypes/Tex.cs
@@ -764,7 +764,7 @@ namespace xivModdingFramework.Textures.FileTypes
             BitConverter.GetBytes(124).CopyTo(header, 4);
 
             // Flags?
-            BitConverter.GetBytes(0).CopyTo(header, 8);
+            BitConverter.GetBytes(0x21007).CopyTo(header, 8);
 
             // Size
             BitConverter.GetBytes(height).CopyTo(header, 12);
@@ -779,12 +779,15 @@ namespace xivModdingFramework.Textures.FileTypes
             // MipMap Count
             BitConverter.GetBytes(mipCount).CopyTo(header, 28);
 
+            // dwCaps. DDSCAPS_MIPMAP(0x40000) + DDSCAPS_TEXTURE(0x1000)
+            BitConverter.GetBytes(mipCount > 1 ? 0x401000 : 0x1000).CopyTo(header, 104);
+
             var startOfPixStruct = 76;
             // Pixel struct size
             BitConverter.GetBytes(32).CopyTo(header, startOfPixStruct);
 
-            // Pixel Flags.  In this case, uncompressed(64) + contains alpha(1).
-            BitConverter.GetBytes(65).CopyTo(header, startOfPixStruct + 4);
+            // Pixel Flags.  In this case, uncompressed(0x40) + contains alpha(0x01).
+            BitConverter.GetBytes(0x41).CopyTo(header, startOfPixStruct + 4);
 
             // DWFourCC, unused
             BitConverter.GetBytes(0).CopyTo(header, startOfPixStruct + 8);

--- a/xivModdingFramework/Textures/FileTypes/Tex.cs
+++ b/xivModdingFramework/Textures/FileTypes/Tex.cs
@@ -1251,14 +1251,6 @@ namespace xivModdingFramework.Textures.FileTypes
                 newTex.AddRange(Dat.MakeType4DatHeader((XivTexFormat)header.TextureFormat, ddsParts, (int)uncompLength, header.Width, header.Height));
 
                 // Texture file header.
-                // CompressDDSBody call above alters individual mipmap sizes, ending up changing the offsets.
-                // Calculate those again here.
-                header.MipMapOffsets[0] = _TexHeaderSize;
-                for (var i = 1; i < header.MipCount; i++)
-                    header.MipMapOffsets[i] = header.MipMapOffsets[i - 1] + (uint)ddsParts[i - 1].Count;
-                header.LoDMips[0] = Math.Min(header.MipCount - 1u, header.LoDMips[0]);
-                header.LoDMips[1] = Math.Min(header.MipCount - 1u, Math.Max(header.LoDMips[0], header.LoDMips[1]));
-                header.LoDMips[2] = Math.Min(header.MipCount - 1u, Math.Max(header.LoDMips[1], header.LoDMips[2]));
                 newTex.AddRange(header.ToBytes());
 
                 // Compressed pixel data.

--- a/xivModdingFramework/Textures/FileTypes/Tex.cs
+++ b/xivModdingFramework/Textures/FileTypes/Tex.cs
@@ -1308,10 +1308,6 @@ namespace xivModdingFramework.Textures.FileTypes
             }
             var header = TexHeader.ReadTexHeader(br);
 
-            // Fix broken tex file headers while we have a chance
-            // This occurs before a tex file is written to game files or ttmp2 modpacks
-            _ = TexHeader.FixUpBrokenMipOffsets(header, lengthIncludingHeader);
-
             List<byte> newTex = new List<byte>();
             // Here we need to read the texture header.
             if (!extentionOrInternalPath.Contains(".atex"))


### PR DESCRIPTION
Fixes multiple issues with Tex file mipmap offset calculations resulting in corrupted Tex file headers. Also provides migration for upgrading old modpacks.

Also TexTools was creating .tex files with 80 extra null bytes at the end, so the fixup function trims that too.

TTMP version is now 2.1, and TTMP 2.0 modpacks will have their textures fixed on import. PMP modpacks will always have their textures fixed on import.

Also contains some changes to the export of DDS files, fixing a couple of compatibility issues with GIMP in particular.