### PR TITLE
Add traditional chinese (TC), remove pre-7.2 CN/KR hacks

### DIFF
--- a/xivModdingFramework/Cache/XivCache.cs
+++ b/xivModdingFramework/Cache/XivCache.cs
@@ -741,11 +741,7 @@ namespace xivModdingFramework.Cache
                 var _companions = new Companions();
                 var list = await _companions.GetUncachedMountList(tx);
 
-                // Don't get the ornament list for the Chinese or Korean clients as they don't have them yet
-                if (_gameInfo.GameLanguage != XivLanguage.Chinese && _gameInfo.GameLanguage != XivLanguage.Korean)
-                {
-                    list.AddRange(await _companions.GetUncachedOrnamentList(tx));
-                }
+                list.AddRange(await _companions.GetUncachedOrnamentList(tx));
 
                 db.BusyTimeout = 3000;
                 db.Open();

--- a/xivModdingFramework/Exd/FileTypes/ExColumnExpectations.cs
+++ b/xivModdingFramework/Exd/FileTypes/ExColumnExpectations.cs
@@ -202,7 +202,6 @@ namespace xivModdingFramework.Exd.FileTypes
             if (language == XivLanguage.Korean)
             {
                 // Set up overrides here if necessary for KR.
-                columnExpectations["Icon"] = (26, ExcelColumnDataType.UInt16);
             }
             else if (language == XivLanguage.Chinese)
             {

--- a/xivModdingFramework/General/Enums/XivLanguage.cs
+++ b/xivModdingFramework/General/Enums/XivLanguage.cs
@@ -34,6 +34,7 @@ namespace xivModdingFramework.General.Enums
         [Description("fr")] French,
         [Description("ko")] Korean,
         [Description("chs")] Chinese,
+        [Description("tc")] TraditionalChinese,
         [Description("none")] None
     }
 


### PR DESCRIPTION
* Removes the pre-7.2 hack that is currently breaking KR version
* Removes a weird check that blocked umbrellas and stuff from loading for CN/KR.
* Adds traditional chinese language support, for the new taiwan (language code "tc") version of the game

The traditional chinese version of the game appears to be compatible with Patch 7.2, so no special hacks are needed for it right now.