### PR TITLE
Fix for "Unable to retrieve PBD information for race" 

### DIFF
--- a/xivModdingFramework/Models/FileTypes/PDB.cs
+++ b/xivModdingFramework/Models/FileTypes/PDB.cs
@@ -330,74 +330,61 @@ namespace xivModdingFramework.Models.FileTypes
         /// <param name="def"></param>
         private static void BuildNewTransfromMatrices(SkeletonData node, Dictionary<string, SkeletonData> skeletonData, DeformationCollection def)
         {
+            // Already processed somehow.  Double listed?
             if (def.InvertedDeformations.ContainsKey(node.BoneName))
+                return;
+
+            if (def.Deformations.ContainsKey(node.BoneName))
             {
-                // Already processed somehow.  Double listed?
-            }
-            else if (node.BoneParent == -1)
-            {
-                if (!def.Deformations.ContainsKey(node.BoneName))
-                {
-                    def.Deformations.Add(node.BoneName, Matrix.Identity);
-                    def.InvertedDeformations.Add(node.BoneName, Matrix.Identity);
-                    def.NormalDeformations.Add(node.BoneName, Matrix.Identity);
-                    def.InvertedNormalDeformations.Add(node.BoneName, Matrix.Identity);
-                }
+                def.InvertedDeformations.Add(node.BoneName, def.Deformations[node.BoneName].Inverted());
+
+                var normalMatrix = def.Deformations[node.BoneName];
+                normalMatrix.Transpose();
+                def.NormalDeformations.Add(node.BoneName, normalMatrix);
+
+                var invertexNormalMatrix = def.Deformations[node.BoneName];
+                normalMatrix.Transpose();
+                invertexNormalMatrix.Invert();
+                def.InvertedNormalDeformations.Add(node.BoneName, invertexNormalMatrix);
             }
             else
             {
-                if (def.Deformations.ContainsKey(node.BoneName))
+                if (node.BoneParent == -1 || !skeletonData.ContainsKey(node.BoneName))
                 {
-                    def.InvertedDeformations.Add(node.BoneName, def.Deformations[node.BoneName].Inverted());
-
-                    var normalMatrix = def.Deformations[node.BoneName];
-                    normalMatrix.Transpose();
-                    def.NormalDeformations.Add(node.BoneName, normalMatrix);
-
-                    var invertexNormalMatrix = def.Deformations[node.BoneName];
-                    normalMatrix.Transpose();
-                    invertexNormalMatrix.Invert();
-                    def.InvertedNormalDeformations.Add(node.BoneName, invertexNormalMatrix);
-
+                    def.Deformations[node.BoneName] = Matrix.Identity;
+                    def.InvertedDeformations[node.BoneName] = Matrix.Identity;
+                    def.NormalDeformations[node.BoneName] = Matrix.Identity;
+                    def.InvertedNormalDeformations[node.BoneName] = Matrix.Identity;
                 }
                 else
                 {
-                    if (!skeletonData.ContainsKey(node.BoneName))
+                    var skelEntry = skeletonData[node.BoneName];
+                    while (skelEntry != null)
+                    {
+                        if (def.Deformations.ContainsKey(skelEntry.BoneName))
+                        {
+                            // This parent has a deform.
+                            def.Deformations[node.BoneName] = def.Deformations[skelEntry.BoneName];
+                            def.InvertedDeformations[node.BoneName] = def.InvertedDeformations[skelEntry.BoneName];
+                            def.NormalDeformations[node.BoneName] = def.NormalDeformations[skelEntry.BoneName];
+                            def.InvertedNormalDeformations[node.BoneName] = def.InvertedNormalDeformations[skelEntry.BoneName];
+                            break;
+                        }
+
+                        // Seek our next parent.
+                        skelEntry = skeletonData.FirstOrDefault(x => x.Value.BoneNumber == skelEntry.BoneParent).Value;
+                    }
+
+                    if (skelEntry == null)
                     {
                         def.Deformations[node.BoneName] = Matrix.Identity;
                         def.InvertedDeformations[node.BoneName] = Matrix.Identity;
                         def.NormalDeformations[node.BoneName] = Matrix.Identity;
                         def.InvertedNormalDeformations[node.BoneName] = Matrix.Identity;
                     }
-                    else
-                    {
-                        var skelEntry = skeletonData[node.BoneName];
-                        while (skelEntry != null)
-                        {
-                            if (def.Deformations.ContainsKey(skelEntry.BoneName))
-                            {
-                                // This parent has a deform.
-                                def.Deformations[node.BoneName] = def.Deformations[skelEntry.BoneName];
-                                def.InvertedDeformations[node.BoneName] = def.InvertedDeformations[skelEntry.BoneName];
-                                def.NormalDeformations[node.BoneName] = def.NormalDeformations[skelEntry.BoneName];
-                                def.InvertedNormalDeformations[node.BoneName] = def.InvertedNormalDeformations[skelEntry.BoneName];
-                                break;
-                            }
-
-                            // Seek our next parent.
-                            skelEntry = skeletonData.FirstOrDefault(x => x.Value.BoneNumber == skelEntry.BoneParent).Value;
-                        }
-
-                        if (skelEntry == null)
-                        {
-                            def.Deformations[node.BoneName] = Matrix.Identity;
-                            def.InvertedDeformations[node.BoneName] = Matrix.Identity;
-                            def.NormalDeformations[node.BoneName] = Matrix.Identity;
-                            def.InvertedNormalDeformations[node.BoneName] = Matrix.Identity;
-                        }
-                    }
                 }
             }
+
             var children = skeletonData.Where(x => x.Value.BoneParent == node.BoneNumber);
             foreach (var c in children)
             {


### PR DESCRIPTION
The addition of a new bone exposed a problem with function to generate racial deforms.

This fixes the function so that `n_root` is properly generated, so that when `n_hara_notrans_anim` tries to copy its parameters, it does not throw an exception and fail.