### PR TITLE
Actually fix racial deformations

### DIFF
--- a/xivModdingFramework/Models/FileTypes/PDB.cs
+++ b/xivModdingFramework/Models/FileTypes/PDB.cs
@@ -336,16 +336,16 @@ namespace xivModdingFramework.Models.FileTypes
 
             if (def.Deformations.ContainsKey(node.BoneName))
             {
-                def.InvertedDeformations.Add(node.BoneName, def.Deformations[node.BoneName].Inverted());
+                var invertedMatrix = def.Deformations[node.BoneName].Inverted();
+                def.InvertedDeformations.Add(node.BoneName, invertedMatrix);
 
-                var normalMatrix = def.Deformations[node.BoneName];
+                var normalMatrix = invertedMatrix;
                 normalMatrix.Transpose();
                 def.NormalDeformations.Add(node.BoneName, normalMatrix);
 
-                var invertexNormalMatrix = def.Deformations[node.BoneName];
-                normalMatrix.Transpose();
-                invertexNormalMatrix.Invert();
-                def.InvertedNormalDeformations.Add(node.BoneName, invertexNormalMatrix);
+                var invertedNormalMatrix = def.Deformations[node.BoneName];
+                invertedNormalMatrix.Transpose();
+                def.InvertedNormalDeformations.Add(node.BoneName, invertedNormalMatrix);
             }
             else
             {

--- a/xivModdingFramework/Models/Helpers/ModelModifiers.cs
+++ b/xivModdingFramework/Models/Helpers/ModelModifiers.cs
@@ -1388,10 +1388,10 @@ namespace xivModdingFramework.Models.Helpers
                             }
 
                             v.Position = position;
-                            v.Normal = normal;
-                            v.Binormal = binormal;
-                            v.Tangent = tangent;
-                            v.FlowDirection = flow;
+                            v.Normal = normal.Normalized();
+                            v.Binormal = binormal.Normalized();
+                            v.Tangent = tangent.Normalized();
+                            v.FlowDirection = flow.Normalized();
                         }
 
                         // Same thing, but for the Shape Data parts.
@@ -1435,10 +1435,10 @@ namespace xivModdingFramework.Models.Helpers
                                 }
 
                                 v.Position = position;
-                                v.Normal = normal;
-                                v.Binormal = binormal;
-                                v.Tangent = tangent;
-                                v.FlowDirection = flow;
+                                v.Normal = normal.Normalized();
+                                v.Binormal = binormal.Normalized();
+                                v.Tangent = tangent.Normalized();
+                                v.FlowDirection = flow.Normalized();
                             }
                         }
 


### PR DESCRIPTION
I messed up racial deformations in #73 trying to fix the normals becoming inverted.

This fixes what I did, and also fixes the actual bug I was trying to fix in the first place, which was basically just a typo...

<img width="537" height="440" alt="image" src="https://github.com/user-attachments/assets/06d2f138-a30a-42f9-8439-df81e47b47f2" />

---

~~I need Sel to review the changes in 36f9162b28cf593dd68962d03e05cf083710c3fb specifically~~ nvm its all good now

I'm pretty sure Normalized() is correct to add here -- otherwise it is generating and saving a model without normalized normals ?
I'm not sure if the flow direction is supposed to be normalized but I just assumed it was.