### PR TITLE
Fix Emote table Icon column type for CN serve

### DIFF
--- a/xivModdingFramework/Exd/FileTypes/ExColumnExpectations.cs
+++ b/xivModdingFramework/Exd/FileTypes/ExColumnExpectations.cs
@@ -580,7 +580,7 @@ namespace xivModdingFramework.Exd.FileTypes
             else if (language == XivLanguage.Chinese)
             {
                 // Set up overrides here if necessary for CN.
-                columnExpectations["Icon"] = (20, ExcelColumnDataType.UInt16);
+                columnExpectations["Icon"] = (20, ExcelColumnDataType.UInt32);
             }
             else if (language == XivLanguage.TraditionalChinese)
             {


### PR DESCRIPTION
The CN client has updated the Emote table structure. Column 20 (Icon) is now UInt32, matching the global client.

Fixes #358：https://github.com/TexTools/FFXIV_TexTools_UI/issues/358