### PR TITLE
Fix dye name lookup for patch 7.5 (stain.exh column 3 to 6)

### DIFF
--- a/xivModdingFramework/General/DataContainers/CharaMakeParameter.cs
+++ b/xivModdingFramework/General/DataContainers/CharaMakeParameter.cs
@@ -22,7 +22,12 @@ namespace xivModdingFramework.General.DataContainers
         public CharaMakeParameterSet(byte[] data)
         {
             // SE adds new color blocks between patches, so calculate the RSP offset from the back instead of hardcoding it
-            var metadataStart = data.Length - (8 * 10 * RacialScalingParameter.TotalByteSize);
+            var rspDataSize = 8 * 10 * RacialScalingParameter.TotalByteSize;
+
+            if (data.Length <= rspDataSize)
+                throw new Exception("CMP Format Changed - Unable to read all CMP data.");
+
+            var metadataStart = data.Length - rspDataSize;
 
             ColorPixels.Capacity = metadataStart / 4;
 
@@ -36,11 +41,7 @@ namespace xivModdingFramework.General.DataContainers
                 ColorPixels.Add(new byte[4] { r, g, b, a });
             }
 
-            var rem = data.Length - metadataStart;
-            var entries = rem / RacialScalingParameter.TotalByteSize;
-
-            if (rem % RacialScalingParameter.TotalByteSize != 0)
-                throw new Exception("CMP Format Changed - Unable to read all CMP data.");
+            var entries = rspDataSize / RacialScalingParameter.TotalByteSize;
 
             for (int i = 0; i < entries; i++)
             {

--- a/xivModdingFramework/General/DataContainers/CharaMakeParameter.cs
+++ b/xivModdingFramework/General/DataContainers/CharaMakeParameter.cs
@@ -19,17 +19,14 @@ namespace xivModdingFramework.General.DataContainers
         private List<RacialScalingParameter> RawRacialData = new List<RacialScalingParameter>();
         private List<byte[]> ColorPixels = new List<byte[]>();
 
-        /// <summary>
-        /// The point in the human.cmp file at which the racial scaling metadata begins.
-        /// </summary>
-        public const int MetadataStart = 0x2a800;
-
         public CharaMakeParameterSet(byte[] data)
         {
-            ColorPixels.Capacity = MetadataStart / 4;
+            // SE adds new color blocks between patches, so calculate the RSP offset from the back instead of hardcoding it
+            var metadataStart = data.Length - (8 * 10 * RacialScalingParameter.TotalByteSize);
 
-            var nextOffset = 0;
-            for(int i = 0; i < MetadataStart; i+= 4)
+            ColorPixels.Capacity = metadataStart / 4;
+
+            for(int i = 0; i < metadataStart; i += 4)
             {
                 var r = data[i];
                 var g = data[i + 1];
@@ -37,29 +34,23 @@ namespace xivModdingFramework.General.DataContainers
                 var a = data[i + 3];
 
                 ColorPixels.Add(new byte[4] { r, g, b, a });
-                nextOffset = i + 4;
             }
 
-            if (nextOffset != MetadataStart) throw new Exception("CMP Format Changed - Unable to read all CMP data.");
-
-            var rem = data.Length - MetadataStart;
+            var rem = data.Length - metadataStart;
             var entries = rem / RacialScalingParameter.TotalByteSize;
+
+            if (rem % RacialScalingParameter.TotalByteSize != 0)
+                throw new Exception("CMP Format Changed - Unable to read all CMP data.");
 
             for (int i = 0; i < entries; i++)
             {
-                var offset = MetadataStart + (i * RacialScalingParameter.TotalByteSize);
+                var offset = metadataStart + (i * RacialScalingParameter.TotalByteSize);
                 var arr = new byte[RacialScalingParameter.TotalByteSize];
 
                 Array.Copy(data, offset, arr, 0, RacialScalingParameter.TotalByteSize);
 
-                var rsp = new RacialScalingParameter(arr);
-                RawRacialData.Add(rsp);
-
-                nextOffset = offset + RacialScalingParameter.TotalByteSize;
+                RawRacialData.Add(new RacialScalingParameter(arr));
             }
-
-            if (nextOffset != data.Length) throw new Exception("CMP Format Changed - Unable to read all CMP data.");
-
         }
 
         public RacialGenderScalingParameter GetScalingParameter(XivSubRace Race, XivGender Gender)

--- a/xivModdingFramework/Materials/FileTypes/STM.cs
+++ b/xivModdingFramework/Materials/FileTypes/STM.cs
@@ -109,15 +109,44 @@ namespace xivModdingFramework.Materials.FileTypes
             var ex = new Ex();
             var exData = await ex.ReadExData(XivEx.stain, tx);
 
+            int nameColumn = -1;
+            bool lookupFailed = false;
+            if (exData.Count > 0)
+            {
+                var sample = exData.First().Value;
+                if (sample.Columns.Count > 6 && sample.Columns[6].Type == ExcelColumnDataType.String)
+                {
+                    nameColumn = 6;
+                }
+                else if (sample.Columns.Count > 3 && sample.Columns[3].Type == ExcelColumnDataType.String)
+                {
+                    nameColumn = 3;
+                }
+                else
+                {
+                    lookupFailed = true;
+                    var layout = string.Join(", ", sample.Columns.Select((c, i) => i + ":" + c.Type));
+                    Trace.WriteLine(
+                        "STM.GetDyeNames: Dye names are no longer accessible at the expected " +
+                        "stain.exh columns (global=6, legacy=3). Observed: [" + layout + "]");
+                }
+            }
 
             foreach (var kv in exData)
             {
                 if (kv.Key == 0) continue;
 
-                var name = (string) kv.Value.GetColumn(3);
                 var dyeId = kv.Key - 1;
+                string name = null;
+                if (nameColumn >= 0)
+                {
+                    name = kv.Value.GetColumn(nameColumn) as string;
+                }
+
                 if (String.IsNullOrEmpty(name)) {
-                    name = "Dye " + dyeId.ToString();
+                    name = lookupFailed
+                        ? "Dye " + dyeId.ToString() + " (name lookup failed - framework needs updating)"
+                        : "Dye " + dyeId.ToString();
                 }
 
                 Dyes.Add(dyeId, name);


### PR DESCRIPTION
Detect the name column index once before the loop by checking column type, with fallback to column 3 for pre-7.5 compatibility.