### PR TITLE
model textures: Support charactertransparency and fix some NPCs being shown as black

### DIFF
--- a/xivModdingFramework/Models/ModelTextures/ModelTexture.cs
+++ b/xivModdingFramework/Models/ModelTextures/ModelTexture.cs
@@ -665,7 +665,7 @@ namespace xivModdingFramework.Models.ModelTextures
             }
 
             if (shaderPack == EShaderPack.Character || shaderPack == EShaderPack.CharacterLegacy || shaderPack == EShaderPack.CharacterGlass
-             || shaderPack == EShaderPack.CharacterScroll || shaderPack == EShaderPack.CharacterInc)
+             || shaderPack == EShaderPack.CharacterScroll || shaderPack == EShaderPack.CharacterInc || shaderPack == EShaderPack.CharacterTransparency)
             {
                 // This is the most common family of shaders that appears on gear, monsters, etc.
                 // Many of its features should be controlled by shader parameters that aren't implemented
@@ -679,6 +679,10 @@ namespace xivModdingFramework.Models.ModelTextures
                     var metalness = 0.0f;
                     var occlusion = 1.0f;
 
+                    var row = GetColorsetRow(colorset, index[0], index[1], visualizeColorset, highlightRow);
+                    uint effectId = (uint)row[24];
+                    bool blueMaskIsAo = effectId == 0 || effectId == 7 || effectId == 10 || effectId == 12 || effectId >= 17;
+
                     if (useTextures)
                     {
                         if (!hasDiffuse)
@@ -686,16 +690,16 @@ namespace xivModdingFramework.Models.ModelTextures
                             diffuse = new Color4(1.0f);
                         }
 
-
                         if (hasMulti)
                         {
-                            float diffuseMask, specMask;
+                            float diffuseMask = 1.0f, specMask;
                             // Construct specular from mask
                             if (shaderPack == EShaderPack.CharacterLegacy)
                             {
                                 // Specular/Gloss flow
 
-                                diffuseMask = mask.Blue;
+                                if (blueMaskIsAo)
+                                    diffuseMask = mask.Blue;
                                 specMask = mask.Red;
                                 roughness = 1 - mask.Green;
 
@@ -706,14 +710,15 @@ namespace xivModdingFramework.Models.ModelTextures
                             }
                             else
                             {
-                                diffuseMask = mask.Blue;
+                                if (blueMaskIsAo)
+                                    diffuseMask = mask.Blue;
                                 specMask = mask.Red;
                                 roughness = mask.Green;
                             }
 
                             if (!settings.GeneratePbrMaps)
                             {
-                                diffuse *= diffuseMask;
+                                 diffuse *= diffuseMask;
                             }
                             else
                             {
@@ -741,8 +746,6 @@ namespace xivModdingFramework.Models.ModelTextures
                     var emissive = new Color4(0, 0, 0, 1.0f);
                     if (useColorset)
                     {
-                        var row = GetColorsetRow(colorset, index[0], index[1], visualizeColorset, highlightRow);
-
                         var diffusePixel = new Color4(row[0], row[1], row[2], 1.0f);
                         var specPixel = new Color4(row[4], row[5], row[6], 1.0f);
                         var emissPixel = new Color4(row[8], row[9], row[10], 1.0f);


### PR DESCRIPTION
<img width="570" height="283" alt="image" src="https://github.com/user-attachments/assets/4bb93e47-0a23-43ba-af48-eaa91c66b7ee" />
after/before of one of the less broken monsters, fixed by reading the "Shader Template ID" field from the colorset to disable treating the blue channel of the mask texture as AO data. Many monsters were drastically more broken and appeared entirely black when they shouldn't.

<img width="611" height="614" alt="image" src="https://github.com/user-attachments/assets/88b52970-480e-4239-a502-7c5fb94c8d91" />
in-game/before/after rendering of an item using charactertransparency.shpk, by simply enabling all the same functionality as the other character-family shaders. Not that accurate but a good enough representation of the item. Some other items are drastically less broken looking with this change.

---

Reference: https://xivmodding.com/books/ff14-asset-reference-document/page/dawntrail-shader-reference-table#bkmrk-shader-id-nonstandar

I got the list of AO enabled effect IDs (0, 7, 10, and 12) via in-game experimentation. Shader IDs 17 and higher were all treated the same, so I just kept the AO behavior enabled for them.